### PR TITLE
Add check to make sure active tab is maintained even after failed login

### DIFF
--- a/spec/features/local_login_spec.rb
+++ b/spec/features/local_login_spec.rb
@@ -5,16 +5,23 @@ require 'rails_helper'
 RSpec.describe 'Local Login', type: :feature do
   include LoginHelpers
 
+  before do
+    stub_ldap_setting(enabled: true)
+  end
+
   let(:user1) { create(:user) }
 
   context 'when user login is incorrect' do
-    it 'shows error banner when login credentials are incorrect' do
+    it 'shows an error banner and the login page again' do
       credentials = { 'user_email' => user1.email, 'user_password' => 'bad_pass' }
       expect { vulcan_sign_in_with('Local Login', credentials) }
         .not_to change(user1, :sign_in_count)
 
       expect(page)
         .to have_selector('.alert-danger', text: 'Invalid Email or password.')
+
+      # Expect the Local Login tab to be active on page reload
+      expect(page.find('a', text: 'Local Login')[:class]).to include('active')
     end
   end
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-Capybara.default_driver = :selenium_chrome_headless
+Capybara.default_driver = ENV['CI'] ? :selenium_chrome_headless : :selenium_chrome


### PR DESCRIPTION
This verifies that the active tab on the page after a user types in a bad username and password is still the local login tab.

Add ENV to switch between selenium_chrome and selenium_chrome_headless.