### PR TITLE
Cleanup display on login page when only Oauth

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,10 +15,6 @@ class ApplicationController < ActionController::Base
     @navigation += helpers.base_navigation if current_user
   end
 
-  def setup_user
-    @user_info = []
-  end
-
   protected
 
   def configure_permitted_parameters

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# This module provides helpers for the devise/sessions views and helps
+# move the logic of figuring out which login settings are enabled or
+# disabled out of the view.
+module SessionsHelper
+  def any_form_providers_enabled?
+    Settings.local_login.enabled || Devise.omniauth_providers.include?(:ldap)
+  end
+
+  def ldap_enabled?
+    Devise.omniauth_providers.include?(:ldap)
+  end
+
+  def local_login_enabled?
+    Settings.local_login.enabled
+  end
+
+  def non_ldap_oauth_providers
+    resource_class.omniauth_providers.reject { |p| p.eql?(:ldap) }
+  end
+
+  def any_oauth_providers_enabled?
+    devise_mapping.omniauthable? && non_ldap_oauth_providers.count.positive?
+  end
+end

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -10,25 +10,27 @@
     = render 'devise/shared/what_is_vulcan'
   .col-md.offset-md-0.offset-lg-1.order-1.order-md-2
     #login
-      %b-card{"no-body" => ""}
-        %b-tabs{:card => "", :fill => "", :pills => ""}
-          - if Devise.omniauth_providers.include?(:ldap)
-            %b-tab{:title => Settings.ldap.servers.values.first['title']}
-              %b-card-text
-                = render 'devise/sessions/ldap'
-          - if Settings.local_login.enabled
-            %b-tab{:active => params[:active_tab].eql?('local') ? true : false, :title => "Local Login"}
-              %b-card-text
-                = render 'devise/sessions/local'
-            %b-tab{:active => params[:active_tab].eql?('registration') ? true : false, :title => "Register"}
-              %b-card-text
-                = render 'devise/registrations/form'
+      - if any_form_providers_enabled?
+        %b-card{"no-body" => ""}
+          %b-tabs{:card => "", :fill => "", :pills => ""}
+            - if ldap_enabled?
+              %b-tab{:title => Settings.ldap.servers.values.first['title']}
+                %b-card-text
+                  = render 'devise/sessions/ldap'
+            - if local_login_enabled?
+              %b-tab{:active => params[:active_tab].eql?('local') ? true : false, :title => "Local Login"}
+                %b-card-text
+                  = render 'devise/sessions/local'
+              %b-tab{:active => params[:active_tab].eql?('registration') ? true : false, :title => "Register"}
+                %b-card-text
+                  = render 'devise/registrations/form'
 
-    - if devise_mapping.omniauthable? && resource_class.omniauth_providers.reject {|p| p.eql?(:ldap)}.count > 0
-      %hr/
+    - if any_oauth_providers_enabled?
+      - if any_form_providers_enabled?
+        %hr/
       .border.rounded
         .p-3
-          - resource_class.omniauth_providers.reject {|p| p.eql?(:ldap)}.each do |provider|
+          - non_ldap_oauth_providers.each do |provider|
             = button_to omniauth_authorize_path(resource_name, provider), class: "btn btn-block btn-light border btn-#{provider}" do
               %i.mdi{class: "mdi-#{provider}","aria-hidden" => "true"}
               Sign in with GitHub


### PR DESCRIPTION
Also remove unused code in application_controller

Move all the logic used in the session view out into the sessions helper.

Only Github Auth enabled:
<img width="806" alt="Screen Shot 2020-06-03 at 11 40 22 AM" src="https://user-images.githubusercontent.com/2308869/83657572-03bf5a80-a58f-11ea-8e1c-dc0f7678934b.png">

All Auth enabled:
<img width="742" alt="Screen Shot 2020-06-03 at 11 41 07 AM" src="https://user-images.githubusercontent.com/2308869/83657647-1e91cf00-a58f-11ea-8db2-bfe21e202b96.png">
