### PR TITLE
Lock minimum app coverage to 100% for PRs

### DIFF
--- a/spec/simplecov_env.rb
+++ b/spec/simplecov_env.rb
@@ -12,6 +12,7 @@ module SimpleCovEnv
     configure_profile
 
     SimpleCov.start
+    SimpleCov.minimum_coverage 100
   end
 
   def configure_profile


### PR DESCRIPTION
Once #101 and #104 are merged we will have 100% test coverage for the application. We should lock this as the minimum so that we do not drop below this again.