### PR TITLE
128 - implement reverting audited attribute changes on Rules

### DIFF
--- a/app/errors/rule_revert_error.rb
+++ b/app/errors/rule_revert_error.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Raised when a Rule cannot be successfully rolled back to a previous state
+class RuleRevertError < StandardError
+  def initialize(id, field)
+    super "Cannot rollback the #{field} field for Control #{id}"
+  end
+end

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -3,12 +3,65 @@
 # Rules, also known as Controls, are the smallest unit of enforceable configuration found in a
 # Benchmark XCCDF.
 class Rule < ApplicationRecord
-  audited except: %i[created_at updated_at locked], max_audits: 1000
+  audited except: %i[project_id created_at updated_at locked], max_audits: 1000
   before_validation :error_if_locked, on: :update
   before_destroy :error_if_locked
 
   has_many :comments, dependent: :destroy
   belongs_to :project
+
+  ##
+  # Build a structure that minimally describes the editing history of a rule
+  # and describes what can be reverted for that rule.
+  #
+  def history
+    audits.order(:created_at).map do |audit|
+      # Each audit can encompass multiple changes on the model (see audited_changes)
+      # `[0...-1]` removes the last audit from the list because the last element
+      # is the current state of the rule.
+      {
+        id: audit.id,
+        name: audit.user&.name || 'Unknown',
+        created_at: audit.created_at.to_i,
+        audited_changes: audit.audited_changes.map do |audited_field, audited_value|
+          # On creation, the `audited_value` will be a single value (i.e. not an Array)
+          # After an edit, the `audited_value` will be an Array where `[0]` is prev and `[1]` is new
+          {
+            field: audited_field,
+            prev_value: (audited_value.is_a?(Array) ? audited_value[0] : nil),
+            new_value: (audited_value.is_a?(Array) ? audited_value[1] : audited_value)
+          }
+        end
+      }
+    end[0...-1]
+  end
+
+  ##
+  # Revert a specific field on a rule from an audit
+  #
+  # Parameters:
+  #    audit (Audited::Audit) - A specific audited record
+  #    field (string) - A specific field to revert from the audit record
+  #
+  def self.revert(user, audit, field)
+    # nil check for audit
+    raise(RuleRevertError('unknown', field)) if audit.nil?
+
+    # `audit.auditable` refers to the rule itself
+    rule = audit.auditable
+
+    # Ensure `auditable` is indeed a rule
+    raise(RuleRevertError('unknown', field)) unless rule.is_a?(Rule)
+
+    # Permissions check for revert
+    raise(RuleRevertError(rule, field)) unless user.can_edit_project?(rule.project)
+
+    # Check that desired field exists in the audit
+    raise(RuleRevertError(rule, field)) unless audit.audited_changes.include?(field)
+
+    rule[field] = audit.audited_changes[field]
+    rule.save
+  end
 
   # Allow an authorized user to unlock a rule
   def self.unlock(user)

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,6 +28,7 @@ module VulcanVue
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
+    config.time_zone = 'UTC'
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/db/migrate/20210810183322_add_description_to_rules.rb
+++ b/db/migrate/20210810183322_add_description_to_rules.rb
@@ -1,0 +1,5 @@
+class AddDescriptionToRules < ActiveRecord::Migration[6.1]
+  def change
+    add_column :rules, :description, :text, default: ''
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_09_213517) do
+ActiveRecord::Schema.define(version: 2021_08_10_183322) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -71,6 +71,7 @@ ActiveRecord::Schema.define(version: 2021_08_09_213517) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "project_id"
+    t.text "description", default: ""
     t.index ["project_id"], name: "index_rules_on_project_id"
   end
 


### PR DESCRIPTION
https://github.com/mitre/vulcan/issues/128

Notable changes
- implement reverting functionality for controls
- adds a `history` instance method to controls that provides a minimal set of data for describing control history on the frontend
- `project_id` is no longer an audited field
- add `description` attribute to `Rule` model

Users allowed to edit a control also have the ability to revert.

I now notice that there is not a `test/` folder in the project. The below is a short test script (ensure that you have an admin in your DB). 
```ruby
rule1 = Rule.first || Rule.create(project: Project.create(name: "Test Project"))
puts rule1.description
rule1.update(description: "new desc 1")
rule1.update(description: "new desc 2")
puts rule1.history
Rule.revert(User.where(admin: true).first, rule1.audits.first, "description")
puts rule1.history
puts rule1.description
```