### PR TITLE
Disable webpacker stylesheet errors in production

### DIFF
--- a/app/views/projects/index.html.haml
+++ b/app/views/projects/index.html.haml
@@ -1,8 +1,7 @@
 - content_for :assets do
   = javascript_pack_tag 'projects'
-  = stylesheet_pack_tag 'projects'
 
 #Projects
   %Projects{                                                   |
     'v-bind:projects': @projects.to_json,                      |
-  }  
+  }

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,8 +1,7 @@
 - content_for :assets do
   = javascript_pack_tag 'users'
-  = stylesheet_pack_tag 'users'
 
 #users
   %Users{                           |
     'v-bind:users': @users.to_json, |
-  }  
+  }

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -17,7 +17,7 @@ default: &default
   cache_manifest: false
 
   # Extract and emit a css file
-  extract_css: false
+  extract_css: true
 
   static_assets_extensions:
     - .jpg


### PR DESCRIPTION
Webpacker has a nasty habit of not compiling css files for components and then causing an error in production when they are missing.
https://github.com/rails/webpacker/issues/2342
https://github.com/rails/webpacker/issues/2059#issuecomment-486577228
This adds an override which causes no errors in production but still allows us to leave the stylesheet_pack_tag for when it is needed.