### PR TITLE
Sticky alerts

### DIFF
--- a/app/javascript/application.scss
+++ b/app/javascript/application.scss
@@ -17,3 +17,11 @@ $mdi-font-path: '~@mdi/font/fonts/';
 .collapsableArrow {
   font-size: 1.5rem;
 }
+
+#alerts {
+  position: sticky;
+  width: 80%;
+  top: 0;
+  height: 0;
+  z-index: 999999999;
+}

--- a/app/javascript/mixins/AlertMixin.vue
+++ b/app/javascript/mixins/AlertMixin.vue
@@ -27,7 +27,7 @@ export default {
       element.className = classes;
       element.textContent = textContent;
       element.setAttribute('role', 'alert');
-      navbar?.insertAdjacentElement('afterend', element);
+      document.getElementById('alerts')?.appendChild(element);
       setTimeout(function() {element.remove()}, 5000);
     }
   }

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -26,6 +26,6 @@ document.addEventListener('turbolinks:load', () => {
   const alerts = document.querySelectorAll(".alert");
   for (const alert of alerts) {
     console.log(alert);
-    setTimeout(function() {alert.remove()}, 5000);
+    //setTimeout(function() {alert.remove()}, 5000);
   }
 })

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -21,9 +21,10 @@
         'v-bind:profile_path': edit_user_registration_path.to_json,          |
         'v-bind:sign_out_path': destroy_user_session_path.to_json            |
       }                                                                      |
-    - if notice
-      %p.alert.alert-success.alert-dismissable= notice
-    - if alert
-      %p.alert.alert-danger.alert-dismissable= alert
+    .mx-auto.pt-2{ id: 'alerts' }
+      - if notice
+        %p.alert.alert-success.alert-dismissable= notice
+      - if alert
+        %p.alert.alert-danger.alert-dismissable= alert
     .pt-5.container{"data-behavior" => "vue"}
       = yield


### PR DESCRIPTION
Alerts are now sticky and more visible when performing async actions that generate them. This is particularly helpful on the control editor page where before when an alert was generated it would only ever be seen if the user scrolled to the top of the window - possibly causing confusion on if an action succeeded or not. This has now been changed to make alerts stick to the top of the window.