### PR TITLE
Rule save comments & generic comment modal

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,6 @@ module.exports = {
   },
   extends: ["plugin:vue/recommended", 'prettier', 'plugin:prettier/recommended' ],
   rules: {
-    'vue/no-mutating-props': 'off', // THIS IS TEMPORARY UNTIL RULE PROP MUTATIONS ARE FIXED
     'max-len': 'off',
     'no-console': 'warn',
     'no-return-await': 'warn',

--- a/app/controllers/rules_controller.rb
+++ b/app/controllers/rules_controller.rb
@@ -48,8 +48,9 @@ class RulesController < ApplicationController
 
   def rule_update_params
     params.require(:rule).permit(
-      :status, :status_justification, :artifact_description, :vendor_comments, :rule_severity,
-      :rule_weight, :version, :title, :ident, :ident_system, :fixtext, :fixtext_fixref, :fix_id,
+      :status, :status_justification, :artifact_description, :vendor_comments,
+      :rule_severity, :rule_weight, :version, :title, :ident, :ident_system, :fixtext,
+      :fix_id, :fixtext_fixref, :audit_comment,
       checks_attributes: %i[id system content_ref_name content_ref_href content _destroy],
       rule_descriptions_attributes: %i[id description _destroy],
       disa_rule_descriptions_attributes: %i[

--- a/app/javascript/components/rules/RuleComments.vue
+++ b/app/javascript/components/rules/RuleComments.vue
@@ -77,7 +77,7 @@ export default {
     // Upon success, emit an event to the parent that indicates that this rule should be re-fetched.
     commentPostSuccess: function (response) {
       this.newCommentBody = "";
-      this.$emit("ruleUpdated", this.rule.id, "comments");
+      this.$root.$emit("refresh:rule", this.rule.id, "comments");
     },
   },
 };

--- a/app/javascript/components/rules/RuleEditor.vue
+++ b/app/javascript/components/rules/RuleEditor.vue
@@ -25,11 +25,12 @@
           <RuleDescriptionForm
             :key="'rule_description_' + index"
             v-for="(description, index) in rule.rule_descriptions_attributes"
+            :rule="rule"
+            :index="index"
             :description="description"
             :disabled="rule.locked"
-            @removeRuleDescription="() => removeRuleDescription(index)"
           />
-          <b-button class="mb-2" @click="addRuleDescription" v-if="rule.locked == false"><i class="mdi mdi-plus"></i>Add Description</b-button>
+          <b-button class="mb-2" @click="$root.$emit('add:description', rule)" v-if="rule.locked == false"><i class="mdi mdi-plus"></i>Add Description</b-button>
         </b-collapse>
       </template> -->
 
@@ -52,12 +53,13 @@
           <DisaRuleDescriptionForm
             v-for="(description, index) in rule.disa_rule_descriptions_attributes"
             :key="'disa_rule_description_' + index"
+            :rule="rule"
+            :index="index"
             :description="description"
             :disabled="rule.locked"
-            @removeDisaRuleDescription="() => removeDisaRuleDescription(index)"
           />
           <!-- This is commented out because there is currently the assumption that users will only need one description -->
-          <!-- <b-button class="mb-2" @click="addDisaRuleDescription" v-if="rule.locked == false"><i class="mdi mdi-plus"></i>Add DISA Description</b-button> -->
+          <!-- <b-button class="mb-2" @click="$root.$emit('add:disaDescription', rule)" v-if="rule.locked == false"><i class="mdi mdi-plus"></i>Add DISA Description</b-button> -->
         </b-collapse>
       </template>
 
@@ -74,12 +76,12 @@
           <CheckForm
             v-for="(check, index) in rule.checks_attributes"
             :key="'checks_' + index"
+            :rule="rule"
+            :index="index"
             :check="check"
             :disabled="rule.locked"
-            :index="index"
-            @removeCheck="() => removeCheck(index)"
           />
-          <b-button v-if="rule.locked == false" class="mb-2" @click="addCheck"
+          <b-button v-if="rule.locked == false" class="mb-2" @click="$root.$emit('add:check', rule)"
             ><i class="mdi mdi-plus" />Add Check</b-button
           >
         </b-collapse>
@@ -116,41 +118,6 @@ export default {
       showDisaRuleDescriptions: false,
       showRuleDescriptions: false,
     };
-  },
-  methods: {
-    addRuleDescription: function () {
-      this.rule.rule_descriptions_attributes.push({
-        description: "",
-        rule_id: this.rule.id,
-        _destroy: false,
-      });
-    },
-    removeRuleDescription: function (index) {
-      this.rule.rule_descriptions_attributes[index]._destroy = true;
-    },
-    addCheck: function () {
-      this.rule.checks_attributes.push({
-        system: "",
-        content_ref_name: "",
-        content_ref_href: "",
-        content: "",
-        rule_id: this.rule.id,
-        _destroy: false,
-      });
-    },
-    removeCheck: function (index) {
-      this.rule.checks_attributes[index]._destroy = true;
-    },
-    addDisaRuleDescription: function () {
-      this.rule.disa_rule_descriptions_attributes.push({
-        description: "",
-        rule_id: this.rule.id,
-        _destroy: false,
-      });
-    },
-    removeDisaRuleDescription: function (index) {
-      this.rule.disa_rule_descriptions_attributes[index]._destroy = true;
-    },
   },
 };
 </script>

--- a/app/javascript/components/rules/RuleEditorHeader.vue
+++ b/app/javascript/components/rules/RuleEditorHeader.vue
@@ -70,7 +70,7 @@ export default {
     },
     manageLockSuccess: function (response) {
       this.alertOrNotifyResponse(response);
-      this.$emit("ruleUpdated", this.rule.id, "all");
+      this.$root.$emit("refresh:rule", this.rule.id);
     },
     saveRule() {
       axios
@@ -80,7 +80,7 @@ export default {
     },
     saveRuleSuccess: function (response) {
       this.alertOrNotifyResponse(response);
-      this.$emit("ruleUpdated", this.rule.id, "all");
+      this.$root.$emit("refresh:rule", this.rule.id);
     },
   },
 };

--- a/app/javascript/components/rules/RuleEditorHeader.vue
+++ b/app/javascript/components/rules/RuleEditorHeader.vue
@@ -16,14 +16,23 @@
       <!-- Disable and enable save & delete buttons based on locked state of rule -->
       <template v-if="rule.locked">
         <span v-b-tooltip.hover class="d-inline-block" title="Control is locked.">
-          <b-button variant="success" disabled>Save Control</b-button>
+          <!-- <b-button variant="success" disabled>Save Control</b-button> -->
         </span>
         <span v-b-tooltip.hover class="d-inline-block" title="Control is locked.">
           <b-button variant="danger" disabled>Delete Control</b-button>
         </span>
       </template>
       <template v-else>
-        <b-button variant="success" @click="saveRule()">Save Control</b-button>
+        <CommentModal
+          title="Save Control"
+          message="Provide a comment that summarizes your changes to this control."
+          :require-non-empty="true"
+          button-text="Save Control"
+          button-variant="success"
+          :button-disabled="false"
+          wrapper-class="d-inline-block"
+          @comment="saveRule($event)"
+        />
         <b-button variant="danger">Delete Control</b-button>
         <!-- <b-button>Duplicate Control</b-button> -->
       </template>
@@ -40,9 +49,12 @@ import axios from "axios";
 import DateFormatMixinVue from "../../mixins/DateFormatMixin.vue";
 import AlertMixinVue from "../../mixins/AlertMixin.vue";
 import FormMixinVue from "../../mixins/FormMixin.vue";
+import CommentModal from "../shared/CommentModal.vue";
+import _ from "lodash";
 
 export default {
   name: "RuleEditorHeader",
+  components: { CommentModal },
   mixins: [DateFormatMixinVue, AlertMixinVue, FormMixinVue],
   props: {
     rule: {
@@ -72,9 +84,13 @@ export default {
       this.alertOrNotifyResponse(response);
       this.$root.$emit("refresh:rule", this.rule.id);
     },
-    saveRule() {
+    saveRule(comment) {
+      let payload = {
+        rule: _.cloneDeep(this.rule),
+      };
+      payload["rule"]["audit_comment"] = comment;
       axios
-        .put(`/rules/${this.rule.id}`, this.rule)
+        .put(`/rules/${this.rule.id}`, payload)
         .then(this.saveRuleSuccess)
         .catch(this.alertOrNotifyResponse);
     },

--- a/app/javascript/components/rules/RuleHistories.vue
+++ b/app/javascript/components/rules/RuleHistories.vue
@@ -16,7 +16,6 @@
         :rule="rule"
         :statuses="statuses"
         :severities="severities"
-        @ruleUpdated="(id) => $emit('ruleUpdated', id)"
       />
     </b-collapse>
   </div>

--- a/app/javascript/components/rules/RuleRevertModal.vue
+++ b/app/javascript/components/rules/RuleRevertModal.vue
@@ -221,7 +221,7 @@ export default {
     },
     revertSuccess: function (response) {
       this.alertOrNotifyResponse(response);
-      this.$emit("ruleUpdated", this.rule.id, "all");
+      this.$root.$emit("refresh:rule", this.rule.id, "all");
     },
   },
 };

--- a/app/javascript/components/rules/Rules.vue
+++ b/app/javascript/components/rules/Rules.vue
@@ -9,7 +9,6 @@
       :rules="reactiveRules"
       :statuses="statuses"
       :severities="severities"
-      @ruleUpdated="ruleUpdated"
     />
   </div>
 </template>
@@ -19,6 +18,7 @@ import axios from "axios";
 import AlertMixinVue from "../../mixins/AlertMixin.vue";
 import RulesCodeEditorView from "./RulesCodeEditorView.vue";
 import FormMixinVue from "../../mixins/FormMixin.vue";
+import _ from "lodash";
 
 export default {
   name: "Rules",
@@ -44,7 +44,7 @@ export default {
   },
   data: function () {
     return {
-      reactiveRules: this.rules,
+      reactiveRules: _.cloneDeep(this.rules),
     };
   },
   computed: {
@@ -65,14 +65,139 @@ export default {
       ];
     },
   },
+  mounted() {
+    this.$root.$on("refresh:rule", this.refreshRule);
+    this.$root.$on("update:rule", this.ruleUpdate);
+    this.$root.$on("update:check", this.checkUpdate);
+    this.$root.$on("update:description", this.descriptionUpdate);
+    this.$root.$on("update:disaDescription", this.disaDescriptionUpdate);
+    this.$root.$on("add:check", this.checkUpdate);
+    this.$root.$on("add:description", this.descriptionUpdate);
+    this.$root.$on("add:disaDescription", this.disaDescriptionUpdate);
+  },
   methods: {
+    /**
+     * Event handler for @add:description
+     */
+    addRuleDescription: function (rule) {
+      const ruleIndex = this.reactiveRules.findIndex((r) => r.id == rule.id);
+      // Guard if rule is not found
+      if (ruleIndex == -1) {
+        return;
+      }
+
+      this.reactiveRules[ruleIndex].rule_descriptions_attributes.push({
+        description: "",
+        rule_id: this.rule.id,
+        _destroy: false,
+      });
+    },
+    /**
+     * Event handler for @add:check
+     */
+    addCheck: function (rule) {
+      const ruleIndex = this.reactiveRules.findIndex((r) => r.id == rule.id);
+      // Guard if rule is not found
+      if (ruleIndex == -1) {
+        return;
+      }
+
+      this.reactiveRules[ruleIndex].checks_attributes.push({
+        system: "",
+        content_ref_name: "",
+        content_ref_href: "",
+        content: "",
+        rule_id: this.rule.id,
+        _destroy: false,
+      });
+    },
+    /**
+     * Event handler for @add:disaDescription
+     */
+    addDisaRuleDescription: function (rule) {
+      const ruleIndex = this.reactiveRules.findIndex((r) => r.id == rule.id);
+      // Guard if rule is not found
+      if (ruleIndex == -1) {
+        return;
+      }
+
+      this.reactiveRules[ruleIndex].disa_rule_descriptions_attributes.push({
+        description: "",
+        rule_id: this.rule.id,
+        _destroy: false,
+      });
+    },
+    /**
+     * Event handler for @update:rule.
+     * Splices the updated version of the rule where the previous rule was.
+     */
+    ruleUpdate: function (rule) {
+      const index = this.reactiveRules.findIndex((r) => r.id == rule.id);
+      // Guard if rule is not found.
+      if (index == -1) {
+        return;
+      }
+
+      this.reactiveRules.splice(index, 1, rule);
+    },
+    /**
+     * Event handler for @update:check
+     * Splices the updated version of the check at the specified index.
+     *
+     * If -1 is passed as the index, then no action will be taken.
+     */
+    checkUpdate: function (rule, check, index) {
+      const ruleIndex = this.reactiveRules.findIndex((r) => r.id == rule.id);
+      // Guard if rule is not found
+      // OR
+      // check index == -1  because -1 is the default if no index is passed to CheckForm.
+      if (ruleIndex == -1 || index == -1) {
+        return;
+      }
+
+      this.reactiveRules[ruleIndex].checks_attributes.splice(index, 1, check);
+    },
+    /**
+     * Event handler for @update:disaDescription
+     * Splices the updated version of the DISA description at the specified index.
+     *
+     * If -1 is passed as the index, then no action will be taken.
+     */
+    disaDescriptionUpdate: function (rule, description, index) {
+      const ruleIndex = this.reactiveRules.findIndex((r) => r.id == rule.id);
+      // Guard if rule is not found
+      // OR
+      // check index == -1  because -1 is the default if no index is passed to DisaRuleDescriptionForm.
+      if (ruleIndex == -1 || index == -1) {
+        return;
+      }
+
+      this.reactiveRules[ruleIndex].disa_rule_descriptions_attributes.splice(index, 1, description);
+    },
+    /**
+     * Event handler for @update:description
+     * Splices the updated version of the description at the specified index.
+     *
+     * If -1 is passed as the index, then no action will be taken.
+     */
+    descriptionUpdate: function (rule, description, index) {
+      const ruleIndex = this.reactiveRules.findIndex((r) => r.id == rule.id);
+      // Guard if rule is not found
+      // OR
+      // check index == -1  because -1 is the default if no index is passed to RuleDescriptionForm.
+      if (ruleIndex == -1 || index == -1) {
+        return;
+      }
+
+      this.reactiveRules[ruleIndex].rule_descriptions_attributes.splice(index, 1, description);
+    },
     /**
      * Indicates to this component that a rule has updated and should be re-fetched.
      *
      * id: The rule ID
      * updated: How the rule is expected to have been changed. Expects any of ['all', 'comments']
      */
-    ruleUpdated: function (id, updated = "all") {
+    refreshRule: function (id, updated = "all") {
       axios
         .get(`/rules/${id}`)
         .then((response) => this.ruleFetchSuccess(response, updated))
@@ -88,10 +213,7 @@ export default {
      * changes just beause a user has commented.
      */
     ruleFetchSuccess: function (response, updated) {
-      const ruleIndex = this.reactiveRules.findIndex((rule) => {
-        return rule.id == response.data.id;
-      });
-
+      const ruleIndex = this.reactiveRules.findIndex((r) => r.id == response.data.id);
       if (updated == "all") {
         this.reactiveRules.splice(ruleIndex, 1, response.data);
       } else if (updated == "comments") {

--- a/app/javascript/components/rules/RulesCodeEditorView.vue
+++ b/app/javascript/components/rules/RulesCodeEditorView.vue
@@ -10,7 +10,7 @@
 
     <template v-if="selectedRuleId != null">
       <div class="col-10">
-        <RuleEditorHeader :rule="selectedRule" @ruleUpdated="(id) => $emit('ruleUpdated', id)" />
+        <RuleEditorHeader :rule="selectedRule" />
 
         <hr />
 
@@ -22,17 +22,9 @@
 
           <!-- Additional info column -->
           <div class="col-5">
-            <RuleComments
-              :rule="selectedRule"
-              @ruleUpdated="(id, updated) => $emit('ruleUpdated', id, updated)"
-            />
+            <RuleComments :rule="selectedRule" />
             <br />
-            <RuleHistories
-              :rule="selectedRule"
-              :statuses="statuses"
-              :severities="severities"
-              @ruleUpdated="(id) => $emit('ruleUpdated', id)"
-            />
+            <RuleHistories :rule="selectedRule" :statuses="statuses" :severities="severities" />
           </div>
         </div>
       </div>

--- a/app/javascript/components/rules/forms/CheckForm.vue
+++ b/app/javascript/components/rules/forms/CheckForm.vue
@@ -18,10 +18,11 @@
       </label>
       <b-form-input
         :id="`ruleEditor-check-system-${mod}`"
-        v-model="check.system"
+        v-model="checkCopy.system"
         :class="inputClass('system')"
         placeholder=""
         :disabled="disabled"
+        @input="$root.$emit('update:check', rule, checkCopy, index)"
       />
       <b-form-valid-feedback v-if="hasValidFeedback('system')">
         {{ validFeedback["system"] }}
@@ -45,10 +46,11 @@
       </label>
       <b-form-input
         :id="`ruleEditor-check-content_ref_name-${mod}`"
-        v-model="check.content_ref_name"
+        v-model="checkCopy.content_ref_name"
         :class="inputClass('content_ref_name')"
         placeholder=""
         :disabled="disabled"
+        @input="$root.$emit('update:check', rule, checkCopy, index)"
       />
       <b-form-valid-feedback v-if="hasValidFeedback('content_ref_name')">
         {{ validFeedback["content_ref_name"] }}
@@ -72,10 +74,11 @@
       </label>
       <b-form-input
         :id="`ruleEditor-check-content_ref_href-${mod}`"
-        v-model="check.content_ref_href"
+        v-model="checkCopy.content_ref_href"
         :class="inputClass('content_ref_href')"
         placeholder=""
         :disabled="disabled"
+        @input="$root.$emit('update:check', rule, checkCopy, index)"
       />
       <b-form-valid-feedback v-if="hasValidFeedback('content_ref_href')">
         {{ validFeedback["content_ref_href"] }}
@@ -99,12 +102,13 @@
       </label>
       <b-form-textarea
         :id="`ruleEditor-check-content-${mod}`"
-        v-model="check.content"
+        v-model="checkCopy.content"
         :class="inputClass('content')"
         placeholder=""
         :disabled="disabled"
         rows="1"
         max-rows="99"
+        @input="$root.$emit('update:check', rule, checkCopy, index)"
       />
       <b-form-valid-feedback v-if="hasValidFeedback('content')">
         {{ validFeedback["content"] }}
@@ -115,7 +119,7 @@
     </b-form-group>
 
     <!-- Remove link -->
-    <a v-if="!disabled" class="clickable text-dark" @click="$emit('removeCheck')">
+    <a v-if="!disabled" class="clickable text-dark" @click="removeCheck()">
       <i class="mdi mdi-trash-can" aria-hidden="true" />
       Remove Check
     </a>
@@ -124,13 +128,23 @@
 
 <script>
 import FormFeedbackMixinVue from "../../../mixins/FormFeedbackMixin.vue";
+import _ from "lodash";
+
 export default {
   name: "CheckForm",
   mixins: [FormFeedbackMixinVue],
+  // `rule` and `index` are necessary if edits are to be made
   props: {
     check: {
       type: Object,
       required: true,
+    },
+    rule: {
+      type: Object,
+    },
+    index: {
+      type: Number,
+      default: -1,
     },
     disabled: {
       type: Boolean,
@@ -140,6 +154,7 @@ export default {
   data: function () {
     return {
       mod: Math.floor(Math.random() * 1000),
+      checkCopy: _.cloneDeep(this.check),
       tooltips: {
         system: null,
         content_ref_name: null,
@@ -147,6 +162,17 @@ export default {
         content: null,
       },
     };
+  },
+  watch: {
+    check: function (_oldVal, _newVal) {
+      this.checkCopy = this.check;
+    },
+  },
+  methods: {
+    removeCheck: function () {
+      this.checkCopy._destroy = true;
+      this.$root.$emit("update:check", this.rule, this.checkCopy, this.index);
+    },
   },
 };
 </script>

--- a/app/javascript/components/rules/forms/DisaRuleDescriptionForm.vue
+++ b/app/javascript/components/rules/forms/DisaRuleDescriptionForm.vue
@@ -5,7 +5,11 @@
     </p>
     <!-- documentable -->
     <b-form-group>
-      <b-form-checkbox v-model="description.documentable" :disabled="disabled">
+      <b-form-checkbox
+        v-model="descriptionCopy.documentable"
+        :disabled="disabled"
+        @input="$root.$emit('update:disaDescription', rule, descriptionCopy, index)"
+      >
         Documentable
         <i
           v-if="tooltips['documentable']"
@@ -31,12 +35,13 @@
       </label>
       <b-form-textarea
         :id="`ruleEditor-disa_rule_description-vuln_discussion-${mod}`"
-        v-model="description.vuln_discussion"
+        v-model="descriptionCopy.vuln_discussion"
         :class="inputClass('vuln_discussion')"
         placeholder=""
         :disabled="disabled"
         rows="1"
         max-rows="99"
+        @input="$root.$emit('update:disaDescription', rule, descriptionCopy, index)"
       />
       <b-form-valid-feedback v-if="hasValidFeedback('vuln_discussion')">
         {{ validFeedback["vuln_discussion"] }}
@@ -60,12 +65,13 @@
       </label>
       <b-form-textarea
         :id="`ruleEditor-disa_rule_description-false_positives-${mod}`"
-        v-model="description.false_positives"
+        v-model="descriptionCopy.false_positives"
         :class="inputClass('false_positives')"
         placeholder=""
         :disabled="disabled"
         rows="1"
         max-rows="99"
+        @input="$root.$emit('update:disaDescription', rule, descriptionCopy, index)"
       />
       <b-form-valid-feedback v-if="hasValidFeedback('false_positives')">
         {{ validFeedback["false_positives"] }}
@@ -89,12 +95,13 @@
       </label>
       <b-form-textarea
         :id="`ruleEditor-disa_rule_description-false_negatives-${mod}`"
-        v-model="description.false_negatives"
+        v-model="descriptionCopy.false_negatives"
         :class="inputClass('false_negatives')"
         placeholder=""
         :disabled="disabled"
         rows="1"
         max-rows="99"
+        @input="$root.$emit('update:disaDescription', rule, descriptionCopy, index)"
       />
       <b-form-valid-feedback v-if="hasValidFeedback('false_negatives')">
         {{ validFeedback["false_negatives"] }}
@@ -118,12 +125,13 @@
       </label>
       <b-form-textarea
         :id="`ruleEditor-disa_rule_description-mitigations-${mod}`"
-        v-model="description.mitigations"
+        v-model="descriptionCopy.mitigations"
         :class="inputClass('mitigations')"
         placeholder=""
         :disabled="disabled"
         rows="1"
         max-rows="99"
+        @input="$root.$emit('update:disaDescription', rule, descriptionCopy, index)"
       />
       <b-form-valid-feedback v-if="hasValidFeedback('mitigations')">
         {{ validFeedback["mitigations"] }}
@@ -147,12 +155,13 @@
       </label>
       <b-form-textarea
         :id="`ruleEditor-disa_rule_description-severity_override_guidance-${mod}`"
-        v-model="description.severity_override_guidance"
+        v-model="descriptionCopy.severity_override_guidance"
         :class="inputClass('severity_override_guidance')"
         placeholder=""
         :disabled="disabled"
         rows="1"
         max-rows="99"
+        @input="$root.$emit('update:disaDescription', rule, descriptionCopy, index)"
       />
       <b-form-valid-feedback v-if="hasValidFeedback('severity_override_guidance')">
         {{ validFeedback["severity_override_guidance"] }}
@@ -176,12 +185,13 @@
       </label>
       <b-form-textarea
         :id="`ruleEditor-disa_rule_description-potential_impacts-${mod}`"
-        v-model="description.potential_impacts"
+        v-model="descriptionCopy.potential_impacts"
         :class="inputClass('potential_impacts')"
         placeholder=""
         :disabled="disabled"
         rows="1"
         max-rows="99"
+        @input="$root.$emit('update:disaDescription', rule, descriptionCopy, index)"
       />
       <b-form-valid-feedback v-if="hasValidFeedback('potential_impacts')">
         {{ validFeedback["potential_impacts"] }}
@@ -205,12 +215,13 @@
       </label>
       <b-form-textarea
         :id="`ruleEditor-disa_rule_description-third_party_tools-${mod}`"
-        v-model="description.third_party_tools"
+        v-model="descriptionCopy.third_party_tools"
         :class="inputClass('third_party_tools')"
         placeholder=""
         :disabled="disabled"
         rows="1"
         max-rows="99"
+        @input="$root.$emit('update:disaDescription', rule, descriptionCopy, index)"
       />
       <b-form-valid-feedback v-if="hasValidFeedback('third_party_tools')">
         {{ validFeedback["third_party_tools"] }}
@@ -234,12 +245,13 @@
       </label>
       <b-form-textarea
         :id="`ruleEditor-disa_rule_description-mitigation_control-${mod}`"
-        v-model="description.mitigation_control"
+        v-model="descriptionCopy.mitigation_control"
         :class="inputClass('mitigation_control')"
         placeholder=""
         :disabled="disabled"
         rows="1"
         max-rows="99"
+        @input="$root.$emit('update:disaDescription', rule, descriptionCopy, index)"
       />
       <b-form-valid-feedback v-if="hasValidFeedback('mitigation_control')">
         {{ validFeedback["mitigation_control"] }}
@@ -263,12 +275,13 @@
       </label>
       <b-form-textarea
         :id="`ruleEditor-disa_rule_description-responsibility-${mod}`"
-        v-model="description.responsibility"
+        v-model="descriptionCopy.responsibility"
         :class="inputClass('responsibility')"
         placeholder=""
         :disabled="disabled"
         rows="1"
         max-rows="99"
+        @input="$root.$emit('update:disaDescription', rule, descriptionCopy, index)"
       />
       <b-form-valid-feedback v-if="hasValidFeedback('responsibility')">
         {{ validFeedback["responsibility"] }}
@@ -292,12 +305,13 @@
       </label>
       <b-form-textarea
         :id="`ruleEditor-disa_rule_description-ia_controls-${mod}`"
-        v-model="description.ia_controls"
+        v-model="descriptionCopy.ia_controls"
         :class="inputClass('ia_controls')"
         placeholder=""
         :disabled="disabled"
         rows="1"
         max-rows="99"
+        @input="$root.$emit('update:disaDescription', rule, descriptionCopy, index)"
       />
       <b-form-valid-feedback v-if="hasValidFeedback('ia_controls')">
         {{ validFeedback["ia_controls"] }}
@@ -307,7 +321,7 @@
       </b-form-invalid-feedback>
     </b-form-group>
     <!-- This is commented out because there is currently the assumption that users will only need one description -->
-    <!-- <a @click="$emit('removeDisaRuleDescription')" class="clickable text-dark" v-if="!disabled">
+    <!-- <a @click="removeDescription()" class="clickable text-dark" v-if="!disabled">
       <i class="mdi mdi-trash-can" aria-hidden="true"></i>
       Remove DISA Description
     </a> -->
@@ -319,10 +333,18 @@ import FormFeedbackMixinVue from "../../../mixins/FormFeedbackMixin.vue";
 export default {
   name: "DisaRuleDescriptionForm",
   mixins: [FormFeedbackMixinVue],
+  // `rule` and `index` are necessary if edits are to be made
   props: {
     description: {
       type: Object,
       required: true,
+    },
+    rule: {
+      type: Object,
+    },
+    index: {
+      type: Number,
+      default: -1,
     },
     disabled: {
       type: Boolean,
@@ -332,6 +354,7 @@ export default {
   data: function () {
     return {
       mod: Math.floor(Math.random() * 1000),
+      descriptionCopy: _.cloneDeep(this.description),
       tooltips: {
         documentable: null,
         vuln_discussion: null,
@@ -346,6 +369,17 @@ export default {
         ia_controls: null,
       },
     };
+  },
+  watch: {
+    description: function (_oldVal, _newVal) {
+      this.descriptionCopy = this.description;
+    },
+  },
+  methods: {
+    removeDescription: function () {
+      this.descriptionCopy._destroy = true;
+      this.$root.$emit("update:disaDescription", this.rule, this.descriptionCopy, this.index);
+    },
   },
 };
 </script>

--- a/app/javascript/components/rules/forms/RuleDescriptionForm.vue
+++ b/app/javascript/components/rules/forms/RuleDescriptionForm.vue
@@ -19,12 +19,13 @@
         </label>
         <b-form-textarea
           :id="`ruleEditor-rule_description-${mod}`"
-          v-model="description.description"
+          v-model="descriptionCopy.description"
           :class="inputClass('description')"
           placeholder=""
           :disabled="disabled"
           rows="1"
           max-rows="99"
+          @input="$root.$emit('update:description', rule, descriptionCopy, index)"
         />
         <b-form-valid-feedback v-if="hasValidFeedback('description')">
           {{ validFeedback["description"] }}
@@ -35,7 +36,7 @@
       </b-form-group>
 
       <!-- Remove link -->
-      <a v-if="!disabled" class="clickable text-dark" @click="$emit('removeRuleDescription')">
+      <a v-if="!disabled" class="clickable text-dark" @click="removeDescription()">
         <i class="mdi mdi-trash-can" aria-hidden="true" />
         Remove Rule Description
       </a>
@@ -45,13 +46,23 @@
 
 <script>
 import FormFeedbackMixinVue from "../../../mixins/FormFeedbackMixin.vue";
+import _ from "lodash";
+
 export default {
   name: "RuleDescriptionForm",
   mixins: [FormFeedbackMixinVue],
+  // `rule` and `index` are necessary if edits are to be made
   props: {
     description: {
       type: Object,
       required: true,
+    },
+    rule: {
+      type: Object,
+    },
+    index: {
+      type: Number,
+      default: -1,
     },
     disabled: {
       type: Boolean,
@@ -61,10 +72,22 @@ export default {
   data: function () {
     return {
       mod: Math.floor(Math.random() * 1000),
+      descriptionCopy: _.cloneDeep(this.description),
       tooltips: {
         rule_description: null,
       },
     };
+  },
+  watch: {
+    description: function (_oldVal, _newVal) {
+      this.descriptionCopy = this.description;
+    },
+  },
+  methods: {
+    removeDescription: function () {
+      this.descriptionCopy._destroy = true;
+      this.$root.$emit("update:description", this.rule, this.descriptionCopy, this.index);
+    },
   },
 };
 </script>

--- a/app/javascript/components/rules/forms/RuleForm.vue
+++ b/app/javascript/components/rules/forms/RuleForm.vue
@@ -14,10 +14,11 @@
       </label>
       <b-form-select
         :id="`ruleEditor-status-${mod}`"
-        v-model="rule.status"
+        v-model="ruleCopy.status"
         :class="inputClass('status')"
         :options="statuses"
         :disabled="disabled"
+        @input="$root.$emit('update:rule', ruleCopy)"
       />
       <b-form-valid-feedback v-if="hasValidFeedback('status')">
         {{ validFeedback["status"] }}
@@ -41,12 +42,13 @@
       </label>
       <b-form-textarea
         :id="`ruleEditor-status_justification-${mod}`"
-        v-model="rule.status_justification"
+        v-model="ruleCopy.status_justification"
         :class="inputClass('status_justification')"
         placeholder=""
         :disabled="disabled"
         rows="1"
         max-rows="99"
+        @input="$root.$emit('update:rule', ruleCopy)"
       />
       <b-form-valid-feedback v-if="hasValidFeedback('status_justification')">
         {{ validFeedback["status_justification"] }}
@@ -57,10 +59,10 @@
     </b-form-group>
 
     <!-- Some fields are only applicable if status is 'Applicable - Configurable' -->
-    <p v-if="rule.status != 'Applicable - Configurable'">
+    <p v-if="ruleCopy.status != 'Applicable - Configurable'">
       <small>Some fields are hidden due to the control's status.</small>
     </p>
-    <template v-if="rule.status == 'Applicable - Configurable'">
+    <template v-if="ruleCopy.status == 'Applicable - Configurable'">
       <!-- title -->
       <b-form-group :id="`ruleEditor-title-group-${mod}`">
         <label :for="`ruleEditor-title-${mod}`">
@@ -75,10 +77,11 @@
         </label>
         <b-form-input
           :id="`ruleEditor-title-${mod}`"
-          v-model="rule.title"
+          v-model="ruleCopy.title"
           :class="inputClass('title')"
           placeholder=""
           :disabled="disabled"
+          @input="$root.$emit('update:rule', ruleCopy)"
         />
         <b-form-valid-feedback v-if="hasValidFeedback('title')">
           {{ validFeedback["title"] }}
@@ -102,10 +105,11 @@
         </label>
         <b-form-input
           :id="`ruleEditor-version-${mod}`"
-          v-model="rule.version"
+          v-model="ruleCopy.version"
           :class="inputClass('version')"
           placeholder=""
           :disabled="disabled"
+          @input="$root.$emit('update:rule', ruleCopy)"
         />
         <b-form-valid-feedback v-if="hasValidFeedback('version')">
           {{ validFeedback["version"] }}
@@ -130,10 +134,11 @@
           </label>
           <b-form-select
             :id="`ruleEditor-rule_severity-${mod}`"
-            v-model="rule.rule_severity"
+            v-model="ruleCopy.rule_severity"
             :class="inputClass('rule_severity')"
             :options="severities"
             :disabled="disabled"
+            @input="$root.$emit('update:rule', ruleCopy)"
           />
           <b-form-valid-feedback v-if="hasValidFeedback('rule_severity')">
             {{ validFeedback["rule_severity"] }}
@@ -157,10 +162,11 @@
           </label>
           <b-form-input
             :id="`ruleEditor-rule_weight-${mod}`"
-            v-model="rule.rule_weight"
+            v-model="ruleCopy.rule_weight"
             :class="inputClass('rule_weight')"
             placeholder=""
             :disabled="disabled"
+            @input="$root.$emit('update:rule', ruleCopy)"
           />
           <b-form-valid-feedback v-if="hasValidFeedback('rule_weight')">
             {{ validFeedback["rule_weight"] }}
@@ -185,12 +191,13 @@
         </label>
         <b-form-textarea
           :id="`ruleEditor-artifact_description-${mod}`"
-          v-model="rule.artifact_description"
+          v-model="ruleCopy.artifact_description"
           :class="inputClass('artifact_description')"
           placeholder=""
           :disabled="disabled"
           rows="1"
           max-rows="99"
+          @input="$root.$emit('update:rule', ruleCopy)"
         />
         <b-form-valid-feedback v-if="hasValidFeedback('artifact_description')">
           {{ validFeedback["artifact_description"] }}
@@ -215,10 +222,11 @@
           </label>
           <b-form-input
             :id="`ruleEditor-fix_id-${mod}`"
-            v-model="rule.fix_id"
+            v-model="ruleCopy.fix_id"
             :class="inputClass('fix_id')"
             placeholder=""
             :disabled="disabled"
+            @input="$root.$emit('update:rule', ruleCopy)"
           />
           <b-form-valid-feedback v-if="hasValidFeedback('fix_id')">
             {{ validFeedback["fix_id"] }}
@@ -242,10 +250,11 @@
           </label>
           <b-form-input
             :id="`ruleEditor-fixtext_fixref-${mod}`"
-            v-model="rule.fixtext_fixref"
+            v-model="ruleCopy.fixtext_fixref"
             :class="inputClass('fixtext_fixref')"
             placeholder=""
             :disabled="disabled"
+            @input="$root.$emit('update:rule', ruleCopy)"
           />
           <b-form-valid-feedback v-if="hasValidFeedback('fixtext_fixref')">
             {{ validFeedback["fixtext_fixref"] }}
@@ -270,12 +279,13 @@
         </label>
         <b-form-textarea
           :id="`ruleEditor-fixtext-${mod}`"
-          v-model="rule.fixtext"
+          v-model="ruleCopy.fixtext"
           :class="inputClass('fixtext')"
           placeholder=""
           :disabled="disabled"
           rows="1"
           max-rows="99"
+          @input="$root.$emit('update:rule', ruleCopy)"
         />
         <b-form-valid-feedback v-if="hasValidFeedback('fixtext')">
           {{ validFeedback["fixtext"] }}
@@ -300,10 +310,11 @@
           </label>
           <b-form-input
             :id="`ruleEditor-ident-${mod}`"
-            v-model="rule.ident"
+            v-model="ruleCopy.ident"
             :class="inputClass('ident')"
             placeholder=""
             :disabled="disabled"
+            @input="$root.$emit('update:rule', ruleCopy)"
           />
           <b-form-valid-feedback v-if="hasValidFeedback('ident')">
             {{ validFeedback["ident"] }}
@@ -327,10 +338,11 @@
           </label>
           <b-form-input
             :id="`ruleEditor-ident_system-${mod}`"
-            v-model="rule.ident_system"
+            v-model="ruleCopy.ident_system"
             :class="inputClass('ident_system')"
             placeholder=""
             :disabled="disabled"
+            @input="$root.$emit('update:rule', ruleCopy)"
           />
           <b-form-valid-feedback v-if="hasValidFeedback('ident_system')">
             {{ validFeedback["ident_system"] }}
@@ -355,7 +367,7 @@
         </label>
         <b-form-textarea
           :id="`ruleEditor-vendor_comments-${mod}`"
-          v-model="rule.vendor_comments"
+          v-model="ruleCopy.vendor_comments"
           :class="inputClass('vendor_comments')"
           placeholder=""
           :disabled="disabled"
@@ -375,6 +387,8 @@
 
 <script>
 import FormFeedbackMixinVue from "../../../mixins/FormFeedbackMixin.vue";
+import _ from "lodash";
+
 export default {
   name: "RuleForm",
   mixins: [FormFeedbackMixinVue],
@@ -399,6 +413,7 @@ export default {
   data: function () {
     return {
       mod: Math.floor(Math.random() * 1000),
+      ruleCopy: _.cloneDeep(this.rule),
       tooltips: {
         status: null,
         status_justification: null,
@@ -415,6 +430,11 @@ export default {
         vendor_comments: null,
       },
     };
+  },
+  watch: {
+    rule: function (_oldVal, _newVal) {
+      this.ruleCopy = this.rule;
+    },
   },
 };
 </script>

--- a/app/javascript/components/shared/CommentModal.vue
+++ b/app/javascript/components/shared/CommentModal.vue
@@ -1,0 +1,126 @@
+<template>
+  <div :class="wrapperClass">
+    <b-button
+      v-b-modal.comment-modal
+      :variant="buttonVariant"
+      :class="buttonClass"
+      :disabled="buttonDisabled"
+    >
+      {{ buttonText }}
+    </b-button>
+
+    <b-modal
+      id="comment-modal"
+      ref="modal"
+      :title="title"
+      centered
+      @show="resetModal"
+      @hidden="resetModal"
+      @ok="handleOk"
+    >
+      <p v-if="message">{{ message }}</p>
+      <form ref="form" @submit.stop.prevent="handleSubmit">
+        <b-form-group
+          label="Comment"
+          label-for="comment-input"
+          :invalid-feedback="invalidFeedback"
+          :state="commentValidState"
+        >
+          <b-form-textarea
+            id="comment-input"
+            v-model="comment"
+            :state="commentValidState"
+            :required="requireNonEmpty"
+          />
+        </b-form-group>
+      </form>
+    </b-modal>
+  </div>
+</template>
+
+<script>
+// CommentModal is for generating a modal that prompts a user to input a comment,
+// then once submitted, emits an event @comment that contains the contents of the
+// comment.
+export default {
+  name: "CommentModal",
+  props: {
+    title: {
+      type: String,
+      required: true,
+    },
+    message: {
+      type: String,
+      default: "",
+    },
+    // Message will be validated to be non-empty
+    requireNonEmpty: {
+      type: Boolean,
+      default: true,
+    },
+    buttonText: {
+      type: String,
+      required: true,
+    },
+    buttonVariant: {
+      type: String,
+      default: "primary",
+    },
+    buttonClass: {
+      type: String,
+      default: "",
+    },
+    buttonDisabled: {
+      type: Boolean,
+      default: false,
+    },
+    wrapperClass: {
+      type: String,
+      default: "",
+    },
+  },
+  data: function () {
+    return {
+      comment: "",
+      commentValidState: null,
+    };
+  },
+  computed: {
+    invalidFeedback: function () {
+      return this.requireNonEmpty ? "Must not be blank" : "";
+    },
+  },
+  mounted() {},
+  methods: {
+    resetModal() {
+      this.comment = "";
+      this.commentValidState = null;
+    },
+    handleOk(bvModalEvt) {
+      // Prevent modal from closing
+      bvModalEvt.preventDefault();
+      // Trigger submit handler
+      this.handleSubmit();
+    },
+    handleSubmit() {
+      // Exit when the form isn't valid
+      if (!this.checkFormValidity()) {
+        return;
+      }
+
+      this.$emit("comment", this.comment);
+
+      // Hide the modal manually
+      this.$nextTick(() => {
+        this.$bvModal.hide("comment-modal");
+      });
+    },
+    checkFormValidity() {
+      this.commentValidState = this.$refs.form.checkValidity();
+      return this.commentValidState;
+    },
+  },
+};
+</script>
+
+<style scoped></style>

--- a/app/javascript/components/shared/History.vue
+++ b/app/javascript/components/shared/History.vue
@@ -7,6 +7,7 @@
       <p class="ml-2 mb-0">
         <small>{{ friendlyDateTime(history.created_at) }}</small>
       </p>
+      <p v-if="history.comment" class="ml-3 mb-0">{{ history.comment }}</p>
       <!-- Edit on the Rule itself -->
       <template v-if="history.auditable_type == 'Rule'">
         <!-- Edit on the rule itself -->

--- a/app/javascript/components/shared/History.vue
+++ b/app/javascript/components/shared/History.vue
@@ -38,7 +38,6 @@
                 :audited_change="audited_change"
                 :statuses="statuses"
                 :severities="severities"
-                @ruleUpdated="(id) => $emit('ruleUpdated', id)"
               />
             </div>
           </b-collapse>
@@ -90,7 +89,6 @@
                 :audited_change="audited_change"
                 :statuses="statuses"
                 :severities="severities"
-                @ruleUpdated="(id) => $emit('ruleUpdated', id)"
               />
             </div>
           </b-collapse>
@@ -123,7 +121,6 @@
                 :audited_change="null"
                 :statuses="statuses"
                 :severities="severities"
-                @ruleUpdated="(id) => $emit('ruleUpdated', id)"
               />
             </div>
           </b-collapse>

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -22,6 +22,7 @@ class ApplicationRecord < ActiveRecord::Base
         auditable_type: audit.auditable_type,
         auditable_id: audit.auditable_id,
         name: audit.user&.name || 'Unknown User',
+        comment: audit.comment,
         created_at: audit.created_at,
         audited_changes: audit.audited_changes.map do |audited_field, audited_value|
           # On creation, the `audited_value` will be a single value (i.e. not an Array)


### PR DESCRIPTION
MUST WAIT ON PR -> https://github.com/mitre/vulcan/pull/219

Notable changes:
- Created generic comment modal to be used in multiple places throughout the app
- Used comment modal to add comments to rule save actions

I expect to also use the modal for things like comments on review requests, reviews, etc.

This PR makes the rule save comment required, but if that is not desired it is easy to change.