### PR TITLE
Control editor persistent settings

### DIFF
--- a/app/javascript/components/rules/RuleEditor.vue
+++ b/app/javascript/components/rules/RuleEditor.vue
@@ -53,6 +53,21 @@ export default {
       advancedEditor: false,
     };
   },
+  watch: {
+    advancedEditor: function (_) {
+      localStorage.setItem("advancedEditor", JSON.stringify(this.advancedEditor));
+    },
+  },
+  mounted: function () {
+    // Persist `advancedEditor` across page loads
+    if (localStorage.getItem("advancedEditor")) {
+      try {
+        this.advancedEditor = JSON.parse(localStorage.getItem("advancedEditor"));
+      } catch (e) {
+        localStorage.removeItem("advancedEditor");
+      }
+    }
+  },
 };
 </script>
 

--- a/app/javascript/components/rules/RuleNavigator.vue
+++ b/app/javascript/components/rules/RuleNavigator.vue
@@ -81,6 +81,21 @@ export default {
       return this.filterRules(openRules);
     },
   },
+  watch: {
+    openRuleIds: function (_) {
+      localStorage.setItem("openRuleIds", JSON.stringify(this.openRuleIds));
+    },
+  },
+  mounted: function () {
+    // Persist `openRuleIds` across page loads
+    if (localStorage.getItem("openRuleIds")) {
+      try {
+        this.openRuleIds = JSON.parse(localStorage.getItem("openRuleIds"));
+      } catch (e) {
+        localStorage.removeItem("openRuleIds");
+      }
+    }
+  },
   methods: {
     // Event handler for when a rule is selected
     ruleSelected: function (rule) {

--- a/app/javascript/components/rules/RulesCodeEditorView.vue
+++ b/app/javascript/components/rules/RulesCodeEditorView.vue
@@ -91,6 +91,21 @@ export default {
       return "Unknown User";
     },
   },
+  watch: {
+    selectedRuleId: function (_) {
+      localStorage.setItem("selectedRuleId", JSON.stringify(this.selectedRuleId));
+    },
+  },
+  mounted: function () {
+    // Persist `selectedRuleId` across page loads
+    if (localStorage.getItem("selectedRuleId")) {
+      try {
+        this.selectedRuleId = JSON.parse(localStorage.getItem("selectedRuleId"));
+      } catch (e) {
+        localStorage.removeItem("selectedRuleId");
+      }
+    }
+  },
   methods: {
     handleRuleSelected: function (event) {
       this.selectedRuleId = event;


### PR DESCRIPTION
Notable Changes:
- Persist advanced editor setting, open controls, and currently selected control across page loads