### PR TITLE
Create and delete rules

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -49,7 +49,15 @@ class ApplicationController < ActionController::Base
         flash.alert = exception.message
         redirect_to '/'
       end
-      format.json { render json: { alert: exception.message }, status: :unauthorized }
+      format.json do
+        render json: {
+          toast: {
+            title: 'Not Authorized.',
+            message: exception.message,
+            variant: 'danger'
+          }
+        }, status: :unauthorized
+      end
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -49,7 +49,7 @@ class ApplicationController < ActionController::Base
         flash.alert = exception.message
         redirect_to '/'
       end
-      format.json { render json: { alert: exception.message } }
+      format.json { render json: { alert: exception.message }, status: :unauthorized }
     end
   end
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -11,7 +11,13 @@ class CommentsController < ApplicationController
     comment = Comment.new(comment_params.merge({ user: current_user, rule: @rule }))
     return if comment.save
 
-    render json: { alert: "Could not create comment. #{comment.errors.full_messages}" }, status: :unprocessable_entity
+    render json: {
+      toast: {
+        title: 'Could not create comment.',
+        message: comment.errors.full_messages,
+        variant: 'danger'
+      }
+    }, status: :unprocessable_entity
   end
 
   private

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -11,7 +11,7 @@ class CommentsController < ApplicationController
     comment = Comment.new(comment_params.merge({ user: current_user, rule: @rule }))
     return if comment.save
 
-    render json: { alert: "Could not create comment. #{comment.errors.full_messages}" }
+    render json: { alert: "Could not create comment. #{comment.errors.full_messages}" }, status: :unprocessable_entity
   end
 
   private

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -24,7 +24,8 @@ class ProjectsController < ApplicationController
     if @project.update(project_params)
       render json: { notice: 'Project updated successfully' }
     else
-      render json: { alert: "Could not update project. #{@project.errors.full_messages}" }
+      render json: { alert: "Could not update project. #{@project.errors.full_messages}" },
+             status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -22,10 +22,15 @@ class ProjectsController < ApplicationController
   # Update project and response with json
   def update
     if @project.update(project_params)
-      render json: { notice: 'Project updated successfully' }
+      render json: { toast: 'Project updated successfully' }
     else
-      render json: { alert: "Could not update project. #{@project.errors.full_messages}" },
-             status: :unprocessable_entity
+      render json: {
+        toast: {
+          title: 'Could not update project.',
+          message: @project.errors.full_messages,
+          variant: 'danger'
+        }
+      }, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/rules_controller.rb
+++ b/app/controllers/rules_controller.rb
@@ -7,8 +7,9 @@ class RulesController < ApplicationController
   before_action :set_rule, only: %i[show update destroy manage_lock revert]
   before_action :set_project, only: %i[index show create update manage_lock revert]
   before_action :set_project_permissions, only: %i[index]
-  before_action :authorize_author_project, only: %i[index show create update destroy revert]
+  before_action :authorize_author_project, only: %i[index show update revert]
   before_action :authorize_review_project, only: %i[manage_lock]
+  before_action :authorize_admin_project, only: %i[create destroy]
 
   def index
     @rules = @project.rules

--- a/app/controllers/rules_controller.rb
+++ b/app/controllers/rules_controller.rb
@@ -26,27 +26,51 @@ class RulesController < ApplicationController
                                              }))
 
     if rule.save
-      render json: { notice: 'Successfully created control.', data: rule }
+      render json: { toast: 'Successfully created control.', data: rule }
     else
-      render json: { alert: "Could not create control. #{rule.errors.full_messages}" }, status: :unprocessable_entity
+      render json: {
+        toast: {
+          title: 'Could not create control.',
+          message: rule.errors.full_messages,
+          variant: 'danger'
+        }
+      }, status: :unprocessable_entity
     end
   end
 
   def update
     if @rule.update(rule_update_params)
-      render json: { notice: 'Successfully updated control.' }
+      render json: { toast: 'Successfully updated control.' }
     else
-      render json: { alert: "Could not update control. #{@rule.errors.full_messages}" }, status: :unprocessable_entity
+      render json: {
+        toast: {
+          title: 'Could not update control.',
+          message: @rule.errors.full_messages,
+          variant: 'danger'
+        }
+      }, status: :unprocessable_entity
     end
   rescue RuleLockedError => e
-    render json: { alert: e.message }
+    render json: {
+      toast: {
+        title: 'Could not update control.',
+        message: e.message,
+        variant: 'danger'
+      }, status: :unprocessable_entity
+    }
   end
 
   def destroy
     if @rule.destroy
-      render json: { notice: 'Successfully deleted control.' }
+      render json: { toast: 'Successfully deleted control.' }
     else
-      render json: { alert: "Could not delete control. #{@rule.errors.full_messages}" }, status: :unprocessable_entity
+      render json: {
+        toast: {
+          title: 'Could not delete control.',
+          message: @rule.errors.full_messages,
+          variant: 'danger'
+        }
+      }, status: :unprocessable_entity
     end
   end
 
@@ -56,14 +80,20 @@ class RulesController < ApplicationController
     # rubocop:disable Rails/SkipsModelValidations
     @rule.update_attribute(:locked, manage_lock_params[:locked])
     # rubocop:enable Rails/SkipsModelValidations
-    render json: { notice: "Successfully #{manage_lock_params[:locked] ? 'locked' : 'unlocked'} control." }
+    render json: { toast: "Successfully #{manage_lock_params[:locked] ? 'locked' : 'unlocked'} control." }
   end
 
   def revert
     Rule.revert(@rule, params[:audit_id], params[:fields], params[:audit_comment])
-    render json: { notice: 'Successfully reverted history for control.' }
+    render json: { toast: 'Successfully reverted history for control.' }
   rescue RuleRevertError => e
-    render json: { alert: e.message }, status: :unprocessable_entity
+    render json: {
+      toast: {
+        title: 'Could not revert history.',
+        message: e.message,
+        variant: 'danger'
+      }
+    }, status: :unprocessable_entity
   end
 
   private

--- a/app/controllers/rules_controller.rb
+++ b/app/controllers/rules_controller.rb
@@ -4,10 +4,10 @@
 # Controller for project rules.
 #
 class RulesController < ApplicationController
-  before_action :set_rule, only: %i[show update manage_lock revert]
+  before_action :set_rule, only: %i[show update destroy manage_lock revert]
   before_action :set_project, only: %i[index show create update manage_lock revert]
   before_action :set_project_permissions, only: %i[index]
-  before_action :authorize_author_project, only: %i[index show create update revert]
+  before_action :authorize_author_project, only: %i[index show create update destroy revert]
   before_action :authorize_review_project, only: %i[manage_lock]
 
   def index
@@ -40,6 +40,14 @@ class RulesController < ApplicationController
     end
   rescue RuleLockedError => e
     render json: { alert: e.message }
+  end
+
+  def destroy
+    if @rule.destroy
+      render json: { notice: 'Successfully deleted control.' }
+    else
+      render json: { alert: "Could not delete control. #{@rule.errors.full_messages}" }, status: :unprocessable_entity
+    end
   end
 
   def manage_lock

--- a/app/javascript/components/rules/RuleEditorHeader.vue
+++ b/app/javascript/components/rules/RuleEditorHeader.vue
@@ -23,6 +23,7 @@
         </span>
       </template>
       <template v-else>
+        <!-- Save rule -->
         <CommentModal
           title="Save Control"
           message="Provide a comment that summarizes your changes to this control."
@@ -33,7 +34,27 @@
           wrapper-class="d-inline-block"
           @comment="saveRule($event)"
         />
-        <b-button variant="danger">Delete Control</b-button>
+
+        <!-- Delete rule -->
+        <b-button v-b-modal.delete-rule-modal variant="danger">Delete Control</b-button>
+        <b-modal
+          id="delete-rule-modal"
+          title="Delete Control"
+          centered
+          @ok="$root.$emit('delete:rule', rule.id)"
+        >
+          <p class="my-4">
+            Are you sure you want to delete this control?<br />This cannot be undone.
+          </p>
+
+          <template #modal-footer="{ cancel, ok }">
+            <!-- Emulate built in modal footer ok and cancel button actions -->
+            <b-button @click="cancel()"> Cancel </b-button>
+            <b-button variant="danger" @click="ok()"> Permanently Delete Control </b-button>
+          </template>
+        </b-modal>
+
+        <!-- Duplicate rule -->
         <!-- <b-button>Duplicate Control</b-button> -->
       </template>
       <b-button v-if="rule.locked" variant="warning" @click="manageLock(false)"

--- a/app/javascript/components/rules/RuleNavigator.vue
+++ b/app/javascript/components/rules/RuleNavigator.vue
@@ -30,6 +30,7 @@
     <p class="mt-3 mb-0">
       <strong>All Controls</strong>
       <i v-b-modal.create-rule-modal class="mdi mdi-plus-thick clickable float-right" />
+      <strong v-b-modal.create-rule-modal class="float-right clickable">add </strong>
     </p>
 
     <!-- New rule modal -->

--- a/app/javascript/components/rules/RuleNavigator.vue
+++ b/app/javascript/components/rules/RuleNavigator.vue
@@ -39,6 +39,7 @@
       title="Create New Control"
       centered
       @show="rule_form_rule_id = ''"
+      @shown="$refs.newRuleIdInput.focus()"
       @ok="
         $root.$emit('create:rule', rule_form_rule_id, (response) =>
           ruleSelected(response.data.data)
@@ -54,6 +55,7 @@
         >
           <b-form-input
             id="rule-id-input"
+            ref="newRuleIdInput"
             v-model="rule_form_rule_id"
             placeholder="Enter control ID"
             autocomplete="off"

--- a/app/javascript/components/rules/RuleNavigator.vue
+++ b/app/javascript/components/rules/RuleNavigator.vue
@@ -27,7 +27,43 @@
       <i v-if="rule.locked" class="mdi mdi-lock float-right" aria-hidden="true" />
     </div>
 
-    <p class="mt-3 mb-0"><strong>All Controls</strong></p>
+    <p class="mt-3 mb-0">
+      <strong>All Controls</strong>
+      <i v-b-modal.create-rule-modal class="mdi mdi-plus-thick clickable float-right" />
+    </p>
+
+    <!-- New rule modal -->
+    <b-modal
+      id="create-rule-modal"
+      ref="modal"
+      title="Create New Control"
+      centered
+      @show="rule_form_rule_id = ''"
+      @ok="
+        $root.$emit('create:rule', rule_form_rule_id, (response) =>
+          ruleSelected(response.data.data)
+        )
+      "
+    >
+      <form ref="form" @submit.stop.prevent="handleSubmit">
+        <b-form-group
+          id="rule-id-input-group"
+          label="Control ID"
+          label-for="rule-id-input"
+          description="This must be unique for the project."
+        >
+          <b-form-input
+            id="rule-id-input"
+            v-model="rule_form_rule_id"
+            placeholder="Enter control ID"
+            autocomplete="off"
+            required
+          />
+        </b-form-group>
+      </form>
+    </b-modal>
+
+    <!-- All rules list -->
     <div
       v-for="rule in filteredRules"
       :key="`rule-${rule.id}`"
@@ -66,6 +102,7 @@ export default {
       // Tried using a `new Set()` for `openRuleIds`, but Vue would not react to changes.
       openRuleIds: [],
       search: "",
+      rule_form_rule_id: "",
     };
   },
   computed: {
@@ -125,10 +162,10 @@ export default {
     },
     // Helper to sort rules by ID
     sortById(rule1, rule2) {
-      if (rule1.id < rule2.id) {
+      if (rule1.rule_id.toLowerCase() < rule2.rule_id.toLowerCase()) {
         return -1;
       }
-      if (rule1.id > rule2.id) {
+      if (rule1.rule_id.toLowerCase() > rule2.rule_id.toLowerCase()) {
         return 1;
       }
       return 0;

--- a/app/javascript/components/rules/RuleRevertModal.vue
+++ b/app/javascript/components/rules/RuleRevertModal.vue
@@ -90,7 +90,7 @@
 
           <template v-else-if="history.auditable_type == 'Rule'">
             <RuleForm
-              :rule="rule"
+              :rule="currentState"
               :statuses="statuses"
               :severities="severities"
               :disabled="true"
@@ -175,6 +175,7 @@
 
 <script>
 import axios from "axios";
+import _ from "lodash";
 
 import AlertMixinVue from "../../mixins/AlertMixin.vue";
 import EmptyObjectMixinVue from "../../mixins/EmptyObjectMixin.vue";
@@ -271,17 +272,20 @@ export default {
         );
       }
 
-      let curState = Object.assign({}, dependentRecord);
+      let curState = _.cloneDeep(dependentRecord);
       if (this.isEmpty(curState)) {
         return {};
       }
 
+      // Remove ID to avoid propagating changes by making rule unidentifiable
+      delete curState.id;
+      // Remove _destroy so that form will not be inadvertently hidden
       delete curState._destroy;
       return curState;
     },
     afterState: function () {
       // Get `currentState` and duplicate for modification
-      let afterState = Object.assign({}, this.currentState);
+      let afterState = _.cloneDeep(this.currentState);
 
       // For each audited_change, check if it is one of the selected properties to revert.
       for (let i = 0; i < this.history.audited_changes.length; i++) {

--- a/app/javascript/components/rules/Rules.vue
+++ b/app/javascript/components/rules/Rules.vue
@@ -79,8 +79,35 @@ export default {
     this.$root.$on("add:description", this.addRuleDescription);
     this.$root.$on("add:disaDescription", this.addDisaRuleDescription);
     this.$root.$on("create:rule", this.createRule);
+    this.$root.$on("delete:rule", this.deleteRule);
   },
   methods: {
+    /**
+     * Event handler for @delete:rule
+     */
+    deleteRule: function (rule_id, successCallback = null) {
+      axios
+        .delete(`/rules/${rule_id}`)
+        .then((response) => {
+          this.alertOrNotifyResponse(response);
+
+          // remove the rule
+          const ruleIndex = this.reactiveRules.findIndex((r) => r.id == rule_id);
+          if (ruleIndex >= 0) {
+            this.reactiveRules.splice(ruleIndex, 1);
+          }
+
+          if (successCallback) {
+            try {
+              successCallback(response);
+            } catch (_) {}
+          }
+        })
+        .catch(this.alertOrNotifyResponse);
+    },
+    /**
+     * Event handler for @create:rule
+     */
     createRule: function (rule_id, successCallback = null) {
       axios
         .post(`/projects/${this.project.id}/rules`, { rule: { rule_id: rule_id } })

--- a/app/javascript/components/rules/RulesCodeEditorView.vue
+++ b/app/javascript/components/rules/RulesCodeEditorView.vue
@@ -8,23 +8,23 @@
       />
     </div>
 
-    <template v-if="selectedRuleId != null">
+    <template v-if="selectedRule()">
       <div class="col-10">
-        <RuleEditorHeader :rule="selectedRule" />
+        <RuleEditorHeader :rule="selectedRule()" />
 
         <hr />
 
         <div class="row">
           <!-- Main editor column -->
           <div class="col-7">
-            <RuleEditor :rule="selectedRule" :statuses="statuses" :severities="severities" />
+            <RuleEditor :rule="selectedRule()" :statuses="statuses" :severities="severities" />
           </div>
 
           <!-- Additional info column -->
           <div class="col-5">
-            <RuleComments :rule="selectedRule" />
+            <RuleComments :rule="selectedRule()" />
             <br />
-            <RuleHistories :rule="selectedRule" :statuses="statuses" :severities="severities" />
+            <RuleHistories :rule="selectedRule()" :statuses="statuses" :severities="severities" />
           </div>
         </div>
       </div>
@@ -80,11 +80,11 @@ export default {
     };
   },
   computed: {
-    selectedRule: function () {
-      return this.rules.find((rule) => rule.id == this.selectedRuleId);
+    selectedRuleIdKey: function () {
+      return `selectedRuleId-${this.project.id}`;
     },
     lastEditor: function () {
-      const histories = this.selectedRule.histories;
+      const histories = this.selectedRule().histories;
       if (histories.length > 0) {
         return histories[histories.length - 1].name;
       }
@@ -93,20 +93,31 @@ export default {
   },
   watch: {
     selectedRuleId: function (_) {
-      localStorage.setItem("selectedRuleId", JSON.stringify(this.selectedRuleId));
+      localStorage.setItem(this.selectedRuleIdKey, JSON.stringify(this.selectedRuleId));
     },
   },
   mounted: function () {
     // Persist `selectedRuleId` across page loads
-    if (localStorage.getItem("selectedRuleId")) {
+    if (localStorage.getItem(this.selectedRuleIdKey)) {
       try {
-        this.selectedRuleId = JSON.parse(localStorage.getItem("selectedRuleId"));
+        this.selectedRuleId = JSON.parse(localStorage.getItem(this.selectedRuleIdKey));
       } catch (e) {
-        localStorage.removeItem("selectedRuleId");
+        localStorage.removeItem(this.selectedRuleIdKey);
       }
     }
   },
   methods: {
+    // This should not be a computed property because it has side effects when
+    // the selected rule ID does not actually exist
+    selectedRule: function () {
+      const foundRule = this.rules.find((rule) => rule.id == this.selectedRuleId);
+      if (foundRule) {
+        return foundRule;
+      }
+
+      this.selectedRuleId = null;
+      return null;
+    },
     handleRuleSelected: function (event) {
       this.selectedRuleId = event;
     },

--- a/app/javascript/components/toaster/Toaster.vue
+++ b/app/javascript/components/toaster/Toaster.vue
@@ -4,6 +4,7 @@
 
 <script>
 import AlertMixinVue from "../../mixins/AlertMixin.vue";
+import _ from "lodash";
 
 export default {
   name: "Toaster",
@@ -19,12 +20,25 @@ export default {
     },
   },
   mounted: function () {
-    this.alertOrNotifyResponse({
-      data: {
-        notice: this.notice,
-        alert: this.alert,
-      },
-    });
+    if (this.notice) {
+      this.alertOrNotifyResponse({
+        data: {
+          toast: this.notice,
+        },
+      });
+    }
+
+    if (this.alert) {
+      this.alertOrNotifyResponse({
+        data: {
+          toast: {
+            title: "Error",
+            variant: "danger",
+            message: this.alert,
+          },
+        },
+      });
+    }
   },
 };
 </script>

--- a/app/javascript/mixins/AlertMixin.vue
+++ b/app/javascript/mixins/AlertMixin.vue
@@ -8,21 +8,43 @@ export default {
     // `response['data']['notice']` and `response['data']['alert']` are
     // valid for generating alerts.
     alertOrNotifyResponse: function (response) {
-      if (response["data"] && response["data"]["notice"]) {
-        this.$bvToast.toast(response["data"]["notice"], {
+      // check for a notice
+      let notice =
+        response["data"] && response["data"]["notice"] ? response["data"]["notice"] : null;
+      if (
+        !notice &&
+        response["response"] &&
+        response["response"]["data"] &&
+        response["response"]["data"]["notice"]
+      ) {
+        notice = response["response"]["data"]["notice"];
+      }
+
+      if (notice) {
+        this.$bvToast.toast(notice, {
           title: `Success`,
           variant: "success",
           solid: true,
         });
-      } else if (response["data"] && response["data"]["alert"]) {
-        this.$bvToast.toast(response["data"]["alert"], {
+      }
+
+      // check for an alert
+      let alert = response["data"] && response["data"]["alert"] ? response["data"]["alert"] : null;
+      if (
+        !notice &&
+        response["response"] &&
+        response["response"]["data"] &&
+        response["response"]["data"]["alert"]
+      ) {
+        alert = response["response"]["data"]["alert"];
+      }
+
+      if (alert) {
+        this.$bvToast.toast(alert, {
           title: `Error`,
           variant: "danger",
           solid: true,
         });
-      } else {
-        // The response did not contain data we can use for an alert or notice.
-        return;
       }
     },
   },

--- a/db/migrate/20210910000716_add_unique_index_for_rule_id_and_project_id.rb
+++ b/db/migrate/20210910000716_add_unique_index_for_rule_id_and_project_id.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexForRuleIdAndProjectId < ActiveRecord::Migration[6.1]
+  def change
+    add_index :rules, [:rule_id, :project_id], unique: true, name: "rules_rule_id_project_id_index"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_18_143114) do
+ActiveRecord::Schema.define(version: 2021_09_10_000716) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -150,6 +150,7 @@ ActiveRecord::Schema.define(version: 2021_08_18_143114) do
     t.string "fixtext_fixref"
     t.string "fix_id"
     t.index ["project_id"], name: "index_rules_on_project_id"
+    t.index ["rule_id", "project_id"], name: "rules_rule_id_project_id_index", unique: true
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
Notable changes
- Can now add new rules from the control edit page
- Can now delete rules from the control edit page
- JSON error responses from controllers now also respond with a non-200 status
- `alertOrNotifyResponse` mixin is a little more generalized to handle various responses
- fixed a bug related to persisting `openRuleId` across page loads
- `rule.rule_id` now must be unique (relative to project) and non-blank
    - added DB index to support this uniqueness constraint
- added `before_create` callback on `Rule` to ensure one check exists (just like disa description)

Open issues/questions:
- What role does a user need to have to create and delete a control?
    - ANSWER - only admin for both