### PR TITLE
SRG import nicer error feedback

### DIFF
--- a/app/controllers/security_requirements_guides_controller.rb
+++ b/app/controllers/security_requirements_guides_controller.rb
@@ -25,7 +25,7 @@ class SecurityRequirementsGuidesController < ApplicationController
       render(json: {
                toast: {
                  title: 'Could not create SRG.',
-                 message: srg.errors.full_messages.join(', ').to_s,
+                 message: srg.errors.full_messages,
                  variant: 'danger'
                },
                status: :unprocessable_entity
@@ -37,7 +37,7 @@ class SecurityRequirementsGuidesController < ApplicationController
     if @srg.destroy
       flash.notice = 'Successfully removed SRG.'
     else
-      flash.alert = "Unable to remove SRG. #{@project_member.errors.full_messages}"
+      flash.alert = "Unable to remove SRG. #{@project_member.errors.full_messages.join(', ')}"
     end
     redirect_to action: 'index'
   end

--- a/app/models/security_requirements_guide.rb
+++ b/app/models/security_requirements_guide.rb
@@ -11,12 +11,16 @@ class SecurityRequirementsGuide < ApplicationRecord
 
   # Since an SRG is top-level, the parameter is the entire parsed benchmark
   def self.from_mapping(benchmark_mapping)
-    SecurityRequirementsGuide.new(
-      srg_id: benchmark_mapping.id,
-      title: benchmark_mapping.title.first,
-      version: "V#{benchmark_mapping.version.version}" \
-               "#{SecurityRequirementsGuide.revision(benchmark_mapping.plaintext.first)}"
-    )
+    # Disabling `Style/RescueModifier` here because the goal is simply just to try and
+    # fetch the attribute, but return `nil` if anything goes wrong with parsing.
+    # rubocop:disable Style/RescueModifier
+    id = benchmark_mapping.id rescue nil
+    title = benchmark_mapping.title.first rescue nil
+    version = "V#{benchmark_mapping.version.version}" \
+              "#{SecurityRequirementsGuide.revision(benchmark_mapping.plaintext.first)}" rescue nil
+    # rubocop:enable Style/RescueModifier
+
+    SecurityRequirementsGuide.new(srg_id: id, title: title, version: version)
   end
 
   # If the SRGs do not conform nicely and this function gets complex, remove the version parse logic


### PR DESCRIPTION
Notable Changes:
- change `SecurityRequirementsGuide.from_mapping` to rescue from parsing errors so that user gets usable feedback in the UI
- JSON failure response in `SecurityRequirementsGuidesController#create` can just return `srg.errors.full_messages` and let the `AlertMixIn` handle formatting on the front end.