### PR TITLE
Add auditing for global user modifications and project members

### DIFF
--- a/app/controllers/rules_controller.rb
+++ b/app/controllers/rules_controller.rb
@@ -11,11 +11,11 @@ class RulesController < ApplicationController
   before_action :authorize_admin_project, only: %i[create destroy]
 
   def index
-    @rules = @project.rules
+    @rules = @project.rules.includes(:reviews, :disa_rule_descriptions, :rule_descriptions, :checks)
   end
 
   def show
-    render json: @rule
+    render json: @rule.to_json(methods: %i[histories])
   end
 
   def create
@@ -26,7 +26,7 @@ class RulesController < ApplicationController
                                              }))
 
     if rule.save
-      render json: { toast: 'Successfully created control.', data: rule }
+      render json: { toast: 'Successfully created control.', data: rule.to_json(methods: %i[histories]) }
     else
       render json: {
         toast: {

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,6 +9,10 @@ class UsersController < ApplicationController
 
   def index
     @users = User.alphabetical.select(:id, :name, :email, :provider, :admin)
+    @histories = Audited.audit_class.includes(:auditable, :user)
+                        .where(auditable_type: 'User')
+                        .order(created_at: :desc)
+                        .map(&:format)
   end
 
   def update

--- a/app/javascript/components/rules/RuleEditorHeader.vue
+++ b/app/javascript/components/rules/RuleEditorHeader.vue
@@ -15,17 +15,17 @@
         This control is under review and cannot be edited at this time.
       </p>
 
-      <!-- Rule info -->
-      <!-- <p>Based on ...</p> -->
-      <p v-if="rule.histories.length > 0">
-        Last updated on {{ friendlyDateTime(rule.updated_at) }} by
-        {{ lastEditor }}
-      </p>
-      <p v-else>Created on {{ friendlyDateTime(rule.created_at) }}</p>
-
-      <!-- Action Buttons -->
-      <!-- Disable and enable save & delete buttons based on locked state of rule -->
       <div v-if="!readOnly">
+        <!-- Rule info -->
+        <!-- <p>Based on ...</p> -->
+        <p v-if="rule.histories.length > 0">
+          Last updated on {{ friendlyDateTime(rule.updated_at) }} by
+          {{ lastEditor }}
+        </p>
+        <p v-else>Created on {{ friendlyDateTime(rule.created_at) }}</p>
+
+        <!-- Action Buttons -->
+        <!-- Disable and enable save & delete buttons based on locked state of rule -->
         <template v-if="rule.locked || rule.review_requestor_id ? true : false">
           <span
             v-b-tooltip.hover

--- a/app/javascript/components/shared/History.vue
+++ b/app/javascript/components/shared/History.vue
@@ -33,7 +33,7 @@
 
       <!-- Create action -->
       <p v-if="history.action == 'create'" class="ml-3 mb-0 text-success">
-        {{ humanizedType(history.auditable_type) }} was Created
+        {{ userIdentifier(history) }} was {{ computeCreationText(history) }}
       </p>
     </div>
   </div>
@@ -73,6 +73,15 @@ export default {
   methods: {
     userIdentifier: function (history) {
       return history.audited_name || `${history.auditable_type} ${history.auditable_id}`;
+    },
+    computeCreationText: function (history) {
+      if (history.auditable_type == "ProjectMember") {
+        return `added to the project with ${
+          history.audited_changes.find((element) => element["field"] == "role")["new_value"]
+        } permissions`;
+      } else {
+        return "Created";
+      }
     },
     computeUpdateText: function (changes) {
       if (changes.field == "admin") {

--- a/app/javascript/components/shared/History.vue
+++ b/app/javascript/components/shared/History.vue
@@ -26,7 +26,7 @@
             </p>
           </div>
           <p v-if="history.action == 'destroy'" class="ml-3 mb-0 text-danger">
-            {{ userIdentifier(history) }} was Deleted
+            {{ userIdentifier(history) }} was {{ computeDeletionText(history) }}
           </p>
         </template>
       </template>
@@ -79,6 +79,13 @@ export default {
         return `was ${changes.new_value ? "promoted to" : "demoted from"} admin`;
       } else {
         return `${changes.field} was updated from ${changes.prev_value} to ${changes.new_value}`;
+      }
+    },
+    computeDeletionText: function (history) {
+      if (history.auditable_type == "ProjectMember") {
+        return "removed from the project";
+      } else {
+        return "Deleted";
       }
     },
   },

--- a/app/javascript/components/shared/History.vue
+++ b/app/javascript/components/shared/History.vue
@@ -11,21 +11,30 @@
 
       <!-- Edit or Delete action -->
       <template v-if="history.action == 'update' || history.action == 'destroy'">
-        <RuleRevertModal
-          v-if="revertable"
-          :rule="rule"
-          :history="history"
-          :statuses="statuses"
-          :severities="severities"
-        />
+        <template v-if="revertable">
+          <RuleRevertModal
+            :rule="rule"
+            :history="history"
+            :statuses="statuses"
+            :severities="severities"
+          />
+        </template>
+        <template v-else>
+          <div v-for="changes in history.audited_changes" :key="changes.id">
+            <p v-if="history.action == 'update'" class="ml-3 mb-0 text-info">
+              {{ userIdentifier(history) }} {{ computeUpdateText(changes) }}
+            </p>
+          </div>
+          <p v-if="history.action == 'destroy'" class="ml-3 mb-0 text-danger">
+            {{ userIdentifier(history) }} was Deleted
+          </p>
+        </template>
       </template>
 
       <!-- Create action -->
-      <template v-if="history.action == 'create'">
-        <p class="ml-3 mb-0 text-success">
-          {{ humanizedType(history.auditable_type) }} was Created.
-        </p>
-      </template>
+      <p v-if="history.action == 'create'" class="ml-3 mb-0 text-success">
+        {{ humanizedType(history.auditable_type) }} was Created
+      </p>
     </div>
   </div>
 </template>
@@ -59,6 +68,18 @@ export default {
     revertable: {
       type: Boolean,
       default: true,
+    },
+  },
+  methods: {
+    userIdentifier: function (history) {
+      return history.audited_name || `${history.auditable_type} ${history.auditable_id}`;
+    },
+    computeUpdateText: function (changes) {
+      if (changes.field == "admin") {
+        return `was ${changes.new_value ? "promoted to" : "demoted from"} admin`;
+      } else {
+        return `${changes.field} was updated from ${changes.prev_value} to ${changes.new_value}`;
+      }
     },
   },
 };

--- a/app/javascript/components/users/Users.vue
+++ b/app/javascript/components/users/Users.vue
@@ -1,21 +1,48 @@
 <template>
   <div>
     <h1>Manage Vulcan Users</h1>
-    <UsersTable :users="users" />
+    <b-col>
+      <b-row>
+        <b-col md="10" class="border-right">
+          <UsersTable :users="users" />
+        </b-col>
+        <b-col>
+          <div class="clickable" @click="showHistory = !showHistory">
+            <h5 class="m-0 d-inline-block">User History</h5>
+
+            <i v-if="showHistory" class="mdi mdi-menu-down superVerticalAlign collapsableArrow" />
+            <i v-if="!showHistory" class="mdi mdi-menu-up superVerticalAlign collapsableArrow" />
+          </div>
+          <b-collapse id="collapse-metadata" v-model="showHistory">
+            <History :histories="histories" :revertable="false" />
+          </b-collapse>
+        </b-col>
+      </b-row>
+    </b-col>
   </div>
 </template>
 
 <script>
 import UsersTable from "./UsersTable.vue";
+import History from "../shared/History.vue";
 
 export default {
   name: "Users",
-  components: { UsersTable },
+  components: { UsersTable, History },
   props: {
     users: {
       type: Array,
       required: true,
     },
+    histories: {
+      type: Array,
+      required: true,
+    },
+  },
+  data: function () {
+    return {
+      showHistory: true,
+    };
   },
 };
 </script>

--- a/app/lib/vulcan_audit.rb
+++ b/app/lib/vulcan_audit.rb
@@ -2,6 +2,9 @@
 
 # Custom Audited class for Vulcan-specific methods for interacting with audits.
 class VulcanAudit < ::Audited::Audit
+  belongs_to :audited_user, class_name: 'User', optional: true
+  before_create :set_username, :find_and_save_audited_user
+
   def self.create_initial_rule_audit_from_mapping(project_id)
     {
       auditable_type: 'Rule',
@@ -10,6 +13,44 @@ class VulcanAudit < ::Audited::Audit
       audited_changes: {
         project_id: project_id
       }
+    }
+  end
+
+  def set_username
+    self.username = user&.name
+  end
+
+  # There are 2 different users associated with an action on a user,
+  # the user who is making the change and the user who the change is applied to
+  def find_and_save_audited_user
+    if auditable.respond_to?(:user)
+      self.audited_user = auditable.user
+    elsif auditable.is_a?(User)
+      self.audited_user = auditable
+    end
+    self.audited_username = audited_user&.name
+  end
+
+  def format
+    # Each audit can encompass multiple changes on the model (see audited_changes)
+    {
+      id: id,
+      action: action,
+      auditable_type: auditable_type,
+      auditable_id: auditable_id,
+      name: username,
+      audited_name: audited_username,
+      comment: comment,
+      created_at: created_at,
+      audited_changes: audited_changes.map do |audited_field, audited_value|
+        # On creation, the `audited_value` will be a single value (i.e. not an Array)
+        # After an edit, the `audited_value` will be an Array where `[0]` is prev and `[1]` is new
+        {
+          field: audited_field,
+          prev_value: (audited_value.is_a?(Array) ? audited_value[0] : nil),
+          new_value: (audited_value.is_a?(Array) ? audited_value[1] : audited_value)
+        }
+      end
     }
   end
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -14,26 +14,6 @@ class ApplicationRecord < ActiveRecord::Base
   def histories(limit = 20)
     return unless defined?(own_and_associated_audits)
 
-    own_and_associated_audits.order(:created_at).limit(limit).map do |audit|
-      # Each audit can encompass multiple changes on the model (see audited_changes)
-      {
-        id: audit.id,
-        action: audit.action,
-        auditable_type: audit.auditable_type,
-        auditable_id: audit.auditable_id,
-        name: audit.user&.name || 'Unknown User',
-        comment: audit.comment,
-        created_at: audit.created_at,
-        audited_changes: audit.audited_changes.map do |audited_field, audited_value|
-          # On creation, the `audited_value` will be a single value (i.e. not an Array)
-          # After an edit, the `audited_value` will be an Array where `[0]` is prev and `[1]` is new
-          {
-            field: audited_field,
-            prev_value: (audited_value.is_a?(Array) ? audited_value[0] : nil),
-            new_value: (audited_value.is_a?(Array) ? audited_value[1] : audited_value)
-          }
-        end
-      }
-    end
+    own_and_associated_audits.order(:created_at).limit(limit).map(&:format)
   end
 end

--- a/app/models/project_member.rb
+++ b/app/models/project_member.rb
@@ -3,6 +3,8 @@
 # A ProjectMember is the has_many: :through Model that stores information
 # about a User's membership of a Project
 class ProjectMember < ApplicationRecord
+  audited except: %i[id created_at updated_at], max_audits: 1000, associated_with: :project
+
   include ProjectMemberConstants
 
   belongs_to :project, counter_cache: true

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -128,12 +128,11 @@ class Rule < ApplicationRecord
   end
 
   ##
-  # Override `as_json` to include dependent records (e.g. comments, histories)
+  # Override `as_json` to include dependent records
   #
   def as_json(options = {})
     super.merge(
       {
-        histories: histories,
         reviews: reviews.as_json.map { |c| c.except('user_id', 'rule_id', 'updated_at') },
         rule_descriptions_attributes: rule_descriptions.as_json.map { |o| o.merge({ _destroy: false }) },
         disa_rule_descriptions_attributes: disa_rule_descriptions.as_json.map { |o| o.merge({ _destroy: false }) },

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,8 @@
 # This is our main user model, local, LDAP, and omniauth users are all stored here.
 # We store provider and UID from the Omniauth provider that is logging a user in.
 class User < ApplicationRecord
+  audited only: %i[admin name email], max_audits: 1000
+
   include ProjectMemberConstants
 
   devise :database_authenticatable, :registerable, :rememberable, :recoverable, :confirmable, :trackable, :validatable

--- a/app/views/rules/index.html.haml
+++ b/app/views/rules/index.html.haml
@@ -5,7 +5,7 @@
 #Rules
   %Rules{                                                       |
     'v-bind:project': @project.to_json,                         |
-    'v-bind:rules': @rules.to_json,                             |
+    'v-bind:rules': @rules.to_json(methods: %i[histories]),     |
     'v-bind:statuses': RuleConstants::STATUSES.to_json,         |
     'v-bind:severities': RuleConstants::SEVERITIES.to_json,     |
     'v-bind:project_permissions': @project_permissions.to_json, |

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -2,6 +2,7 @@
   = javascript_pack_tag 'users'
 
 #users
-  %Users{                           |
-    'v-bind:users': @users.to_json, |
+  %Users{                                   |
+    'v-bind:users': @users.to_json,        |
+    'v-bind:histories': @histories.to_json |
   }

--- a/db/migrate/20210930162822_add_audited_user_and_username_to_audits.rb
+++ b/db/migrate/20210930162822_add_audited_user_and_username_to_audits.rb
@@ -1,0 +1,6 @@
+class AddAuditedUserAndUsernameToAudits < ActiveRecord::Migration[6.1]
+  def change
+    add_column :audits, :audited_user_id, :integer
+    add_column :audits, :audited_username, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -30,6 +30,8 @@ ActiveRecord::Schema.define(version: 2021_09_30_182147) do
     t.string "remote_address"
     t.string "request_uuid"
     t.datetime "created_at"
+    t.integer "audited_user_id"
+    t.string "audited_username"
     t.index ["associated_type", "associated_id"], name: "associated_index"
     t.index ["auditable_type", "auditable_id", "version"], name: "auditable_index"
     t.index ["created_at"], name: "index_audits_on_created_at"


### PR DESCRIPTION
This adds additional logging for user modification events at a global level as well as on a per project level. 

Closes #210

On the project show page:
![Screen Shot 2021-09-30 at 2 25 20 PM](https://user-images.githubusercontent.com/2308869/135510472-4fcb61a8-0b25-49b0-8fa3-54cb0ccfda1d.png)

On the global user management page:
![Screen Shot 2021-09-30 at 2 26 16 PM](https://user-images.githubusercontent.com/2308869/135510574-20a9733b-43fe-437c-a722-59f64653ae69.png)


