### PR TITLE
Migrate STIG IDs to be based on the project prefix + rule ID instead of project prefix + database ID

### DIFF
--- a/app/controllers/rules_controller.rb
+++ b/app/controllers/rules_controller.rb
@@ -22,7 +22,8 @@ class RulesController < ApplicationController
   def create
     rule = create_or_duplicate
     if rule.save
-      render json: { toast: 'Successfully created control.', data: rule.to_json(methods: %i[histories]) }
+      render json: { toast: 'Successfully created control.',
+                     data: rule.to_json(methods: %i[histories nist_control_family]) }
     else
       render json: {
         toast: {
@@ -79,9 +80,8 @@ class RulesController < ApplicationController
 
   def create_or_duplicate
     if authorize_author_project.nil? && rule_create_params[:duplicate]
-      rule = Rule.find(rule_create_params[:id]).amoeba_dup
-      rule.rule_id = rule_create_params[:rule_id]
-      rule
+      Rule.find(rule_create_params[:id]).amoeba_dup
+
     elsif authorize_admin_project.nil?
       Rule.new(rule_create_params.except(:duplicate).merge({
                                                              component: @component,
@@ -92,7 +92,7 @@ class RulesController < ApplicationController
   end
 
   def rule_create_params
-    params.require(:rule).permit(:rule_id, :duplicate, :id)
+    params.require(:rule).permit(:duplicate, :id)
   end
 
   def rule_update_params

--- a/app/javascript/components/rules/RuleEditorHeader.vue
+++ b/app/javascript/components/rules/RuleEditorHeader.vue
@@ -6,7 +6,7 @@
         <i v-if="rule.locked" class="mdi mdi-lock" aria-hidden="true" />
         <i v-if="rule.review_requestor_id" class="mdi mdi-file-find" aria-hidden="true" />
         <i v-if="rule.changes_requested" class="mdi mdi-delta" aria-hidden="true" />
-        {{ `${projectPrefix}-${rule.id}` }} // {{ rule.version }}
+        {{ `${projectPrefix}-${rule.rule_id}` }} // {{ rule.version }}
       </h2>
 
       <p v-if="!readOnly && rule.locked" class="text-danger font-weight-bold">
@@ -32,6 +32,7 @@
           :id-prefix="'duplicate'"
           :for-duplicate="true"
           :selected-rule-id="rule.id"
+          :selected-rule-text="`${projectPrefix}-${rule.rule_id}`"
           @ruleSelected="$emit('ruleSelected', $event.id)"
         />
         <b-button v-b-modal.duplicate-rule-modal variant="primary">Duplicate Control</b-button>

--- a/app/javascript/components/rules/RuleNavigator.vue
+++ b/app/javascript/components/rules/RuleNavigator.vue
@@ -121,7 +121,7 @@
           aria-hidden="true"
           @click.stop="ruleDeselected(rule)"
         />
-        {{ formatRuleId(rule.id) }}
+        {{ formatRuleId(rule.rule_id) }}
         <i
           v-if="rule.review_requestor_id"
           class="mdi mdi-file-find float-right"
@@ -145,9 +145,9 @@
 
     <!-- New rule modal -->
     <NewRuleModalForm
-      :title="'Create New Control'"
+      title="Create New Control"
       :for-duplicate="false"
-      :id-prefix="'create'"
+      id-prefix="create"
       @ruleSelected="ruleSelected($event)"
     />
 
@@ -158,7 +158,7 @@
       :class="ruleRowClass(rule)"
       @click="ruleSelected(rule)"
     >
-      {{ formatRuleId(rule.id) }}
+      {{ formatRuleId(rule.rule_id) }}
       <i v-if="rule.review_requestor_id" class="mdi mdi-file-find float-right" aria-hidden="true" />
       <i v-if="rule.locked" class="mdi mdi-lock float-right" aria-hidden="true" />
       <i v-if="rule.changes_requested" class="mdi mdi-delta float-right" aria-hidden="true" />
@@ -419,7 +419,7 @@ export default {
         "vuln_discussion",
       ];
       // Start with the rule ID as searchable
-      let searchText = this.formatRuleId(rule.id);
+      let searchText = this.formatRuleId(rule.rule_id);
       // The `|| ''` statements below prevent the literal string 'undefined' from being part of the searchable text
       // Add all rule attrs for rule
       for (var attrIndex = 0; attrIndex < ruleSearchAttrs.length; attrIndex++) {

--- a/app/javascript/components/rules/forms/NewRuleModalForm.vue
+++ b/app/javascript/components/rules/forms/NewRuleModalForm.vue
@@ -10,31 +10,8 @@
     >
       <form ref="form" method="post">
         <!-- Hide the rule_id (SV-#) input when duplicating the control and show a confirmation -->
-        <div v-if="forDuplicate">Duplicate control {{ selectedRuleId }}?</div>
-        <b-form-group
-          id="rule-id-input-group"
-          label-for="rule-id-input"
-          description="This must be unique for the project. It will not appear in the sidebar and is hidden."
-          :hidden="forDuplicate"
-        >
-          <label :for="`rule-id-input`">
-            Control ID
-            <i
-              v-if="tooltips['control_id']"
-              v-b-tooltip.hover.html
-              class="mdi mdi-information"
-              aria-hidden="true"
-              :title="tooltips['control_id']"
-            />
-          </label>
-          <b-form-input
-            id="rule-id-input"
-            ref="newRuleIdInput"
-            v-model="ruleFormRuleId"
-            autocomplete="off"
-            required
-          />
-        </b-form-group>
+        <div v-if="forDuplicate">Duplicate control {{ selectedRuleText }}?</div>
+        <div v-else>Create a new control in this project?</div>
       </form>
     </b-modal>
   </div>
@@ -61,27 +38,22 @@ export default {
       type: Number,
       required: false,
     },
+    selectedRuleText: {
+      type: String,
+      required: false,
+    },
   },
   data: function () {
-    return {
-      ruleFormRuleId: "",
-      tooltips: {
-        control_id: "This will be equivalent to the SV-#",
-      },
-    };
+    return {};
   },
   mounted: function () {
     this.ruleFormRuleId = this.generateRuleId();
   },
   methods: {
-    generateRuleId: function () {
-      return `VULCAN-${Math.ceil(Math.random() * 1000000)}`;
-    },
     handleSubmit: function () {
-      this.ruleFormRuleId = this.generateRuleId();
       this.$root.$emit(
         "create:rule",
-        { rule_id: this.ruleFormRuleId, duplicate: this.forDuplicate, id: this.selectedRuleId },
+        { duplicate: this.forDuplicate, id: this.selectedRuleId },
         (response) => {
           this.$emit("ruleSelected", response.data.data);
         }

--- a/db/migrate/20211026210423_add_component_and_rule_id_index_to_rule.rb
+++ b/db/migrate/20211026210423_add_component_and_rule_id_index_to_rule.rb
@@ -1,0 +1,5 @@
+class AddComponentAndRuleIdIndexToRule < ActiveRecord::Migration[6.1]
+  def change
+    add_index :rules, [:rule_id, :component_id], name: 'rule_id_and_component_id', unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_25_174911) do
+ActiveRecord::Schema.define(version: 2021_10_26_210423) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -178,6 +178,7 @@ ActiveRecord::Schema.define(version: 2021_10_25_174911) do
     t.boolean "changes_requested", default: false
     t.index ["component_id"], name: "index_rules_on_component_id"
     t.index ["review_requestor_id"], name: "index_rules_on_review_requestor_id"
+    t.index ["rule_id", "component_id"], name: "rule_id_and_component_id", unique: true
   end
 
   create_table "security_requirements_guides", force: :cascade do |t|


### PR DESCRIPTION
This makes it possible to maintain rule IDs across duplications since the ID does not have to be unique across the whole project.

This works towards closing #278 however since the duplicate functionality does not currently work it does not fully complete the work that has to be done.
