### PR TITLE
Allow admins to edit a released component

### DIFF
--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -113,11 +113,8 @@ class Review < ApplicationRecord
   # should only be able to unlock a control if
   # - current user is admin
   # - control is locked
-  # - component is not released
   def can_unlock_control
-    if component.released
-      errors.add(:base, 'Cannot unlock a control on a component that has been released')
-    elsif project_permissions != 'admin'
+    if project_permissions != 'admin'
       errors.add(:base, 'Only an admin can unlock')
     elsif !rule.review_requestor_id.nil?
       errors.add(:base, 'Cannot unlock a control that is currently under review')

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -35,8 +35,7 @@ class Rule < ApplicationRecord
 
   accepts_nested_attributes_for :rule_descriptions, :disa_rule_descriptions, :checks, :references, allow_destroy: true
 
-  validate :cannot_be_locked_and_under_review,
-           :component_must_not_be_released
+  validate :cannot_be_locked_and_under_review
   validate :review_fields_cannot_change_with_other_fields, on: :update
 
   validates :status, inclusion: {
@@ -183,12 +182,6 @@ class Rule < ApplicationRecord
 
   def set_rule_id
     self.rule_id = (component.largest_rule_id + 1).to_s.rjust(6, '0') unless rule_id
-  end
-
-  def component_must_not_be_released
-    return unless component.released
-
-    errors.add(:base, 'Cannot make modifications to a component that has been released')
   end
 
   def cannot_be_locked_and_under_review

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -61,7 +61,7 @@ class User < ApplicationRecord
   end
 
   def can_author_component?(component)
-    admin || PROJECT_MEMBER_AUTHORS.include?(effective_permissions(component))
+    admin || (PROJECT_MEMBER_AUTHORS.include?(effective_permissions(component)) unless component.released)
   end
 
   def can_review_component?(component)


### PR DESCRIPTION
Moved the model level validation of component release to the controller level to have access to the current user. I tried to do this in a way that doesn't change a lot of existing functionality, but let me know if I should be doing this differently.

Closes #260