### PR TITLE
Add support for arbitrary fields on Rules from Components

### DIFF
--- a/app/controllers/components_controller.rb
+++ b/app/controllers/components_controller.rb
@@ -121,7 +121,7 @@ class ComponentsController < ApplicationController
       :released,
       :version,
       :advanced_fields,
-      additional_questions_attributes: [ :id, :name, :question_type, :_destroy, options: [] ],
+      additional_questions_attributes: [:id, :name, :question_type, :_destroy, { options: [] }],
       component_metadata_attributes: { data: {} }
     )
   end

--- a/app/controllers/components_controller.rb
+++ b/app/controllers/components_controller.rb
@@ -106,7 +106,7 @@ class ComponentsController < ApplicationController
 
   def set_component
     @component = Component.eager_load(
-      rules: [:reviews, :disa_rule_descriptions, :rule_descriptions, :checks, {
+      rules: [:reviews, :disa_rule_descriptions, :rule_descriptions, :checks, :additional_answers, {
         srg_rule: %i[disa_rule_descriptions rule_descriptions checks]
       }]
     ).find(params[:id])
@@ -121,6 +121,7 @@ class ComponentsController < ApplicationController
       :released,
       :version,
       :advanced_fields,
+      additional_questions_attributes: [ :id, :name, :question_type, :_destroy, options: [] ],
       component_metadata_attributes: { data: {} }
     )
   end

--- a/app/controllers/rules_controller.rb
+++ b/app/controllers/rules_controller.rb
@@ -12,7 +12,7 @@ class RulesController < ApplicationController
   before_action :authorize_admin_component, only: %i[destroy]
 
   def index
-    @rules = @component.rules.eager_load(:reviews, :disa_rule_descriptions, :rule_descriptions, :checks,
+    @rules = @component.rules.eager_load(:reviews, :disa_rule_descriptions, :rule_descriptions, :checks, :additional_answers,
                                          srg_rule: %i[disa_rule_descriptions rule_descriptions checks])
   end
 
@@ -104,6 +104,7 @@ class RulesController < ApplicationController
       :fix_id, :fixtext_fixref, :audit_comment,
       checks_attributes: %i[id system content_ref_name content_ref_href content _destroy],
       rule_descriptions_attributes: %i[id description _destroy],
+      additional_answers_attributes: %i[id additional_question_id answer],
       disa_rule_descriptions_attributes: %i[
         id vuln_discussion false_positives false_negatives documentable mitigations
         severity_override_guidance potential_impacts third_party_tools mitigation_control
@@ -136,7 +137,7 @@ class RulesController < ApplicationController
     @project = if @component
                  @component.project
                else
-                 Project.includes({ rules: %i[reviews checks disa_rule_descriptions rule_descriptions] })
+                 Project.includes({ rules: %i[reviews checks disa_rule_descriptions rule_descriptions additional_answers] })
                         .find(@component.project_id || params[:project_id] || params.dig(:rule, :project_id))
                end
   end

--- a/app/controllers/rules_controller.rb
+++ b/app/controllers/rules_controller.rb
@@ -12,7 +12,8 @@ class RulesController < ApplicationController
   before_action :authorize_admin_component, only: %i[destroy]
 
   def index
-    @rules = @component.rules.eager_load(:reviews, :disa_rule_descriptions, :rule_descriptions, :checks, :additional_answers,
+    @rules = @component.rules.eager_load(:reviews, :disa_rule_descriptions, :rule_descriptions, :checks,
+                                         :additional_answers,
                                          srg_rule: %i[disa_rule_descriptions rule_descriptions checks])
   end
 
@@ -137,7 +138,8 @@ class RulesController < ApplicationController
     @project = if @component
                  @component.project
                else
-                 Project.includes({ rules: %i[reviews checks disa_rule_descriptions rule_descriptions additional_answers] })
+                 Project.includes({ rules: %i[reviews checks disa_rule_descriptions rule_descriptions
+                                              additional_answers] })
                         .find(@component.project_id || params[:project_id] || params.dig(:rule, :project_id))
                end
   end

--- a/app/javascript/components/components/AddQuestionsModal.vue
+++ b/app/javascript/components/components/AddQuestionsModal.vue
@@ -1,0 +1,122 @@
+<template>
+  <div>
+    <b-button class="px-2 m-2" variant="success" @click="showModal()">
+      Update Additional Questions
+    </b-button>
+    <b-modal
+      ref="addQuestionsToComponentModal"
+      title="Add Questions to Component"
+      size="lg"
+      ok-title="Update"
+      @show="resetModal()"
+      @ok="updateQuestions()"
+    >
+      <b-form @submit="updateQuestions()">
+        <div v-for="(data, index) in questions" :key="index" class="pb-2">
+          <b-input-group>
+            <b-col sm="3" class="px-0">
+              <b-form-select
+                v-model="data.question_type"
+                :options="typeOptions"
+                class="rounded-0"
+              />
+            </b-col>
+            <b-col class="px-0">
+              <b-form-input
+                v-model="data.name"
+                placeholder="Field Name"
+                class="rounded-0"
+                required
+              />
+            </b-col>
+            <b-col v-if="data.question_type === 'dropdown'" sm="5" class="px-0">
+              <b-form-input
+                :value="data.options.join(', ')"
+                placeholder="Values (Comma Separated)"
+                class="rounded-0"
+                required
+                @change="data.options = $event.split(',').map((s) => s.trim())"
+              />
+              <!-- Add button for removing field entry -->
+            </b-col>
+            <b-col sm="1" class="px-0">
+              <b-button variant="danger" class="ml-2" @click="removeQuestions(index)"> X </b-button>
+            </b-col>
+          </b-input-group>
+        </div>
+        <b-row>
+          <b-col>
+            <b-button @click="addQuestions">Add</b-button>
+          </b-col>
+        </b-row>
+        <!-- Allow the enter button to submit the form -->
+        <b-btn type="submit" class="d-none" @click.prevent="updateMetadata()" />
+      </b-form>
+    </b-modal>
+  </div>
+</template>
+
+<script>
+import axios from "axios";
+import FormMixinVue from "../../mixins/FormMixin.vue";
+import AlertMixinVue from "../../mixins/AlertMixin.vue";
+
+function initialState(component) {
+  return {
+    questions: [...component.additional_questions],
+    deleted_questions: [],
+    typeOptions: [
+      { value: "freeform", text: "Freeform Text" },
+      { value: "dropdown", text: "Multiple Select" },
+    ],
+  };
+}
+
+export default {
+  name: "AddQuestionsToComponentModal",
+  mixins: [AlertMixinVue, FormMixinVue],
+  props: {
+    component: {
+      type: Object,
+      required: true,
+    },
+  },
+  data: function () {
+    return initialState(this.component);
+  },
+  methods: {
+    addQuestions: function () {
+      this.questions.push({ name: "", question_type: "freeform", options: [] });
+    },
+    showModal: function () {
+      this.$refs["addQuestionsToComponentModal"].show();
+    },
+    resetModal: function () {
+      Object.assign(this.$data, initialState(this.component));
+    },
+    removeQuestions: function (index) {
+      let currentQuestion = this.questions.splice(index, 1)[0];
+      currentQuestion._destroy = true;
+      this.deleted_questions.push(currentQuestion);
+    },
+    updateQuestions: function () {
+      this.$refs["addQuestionsToComponentModal"].hide();
+      let payload = {
+        component: {
+          additional_questions_attributes: this.questions.concat(this.deleted_questions),
+        },
+      };
+      axios
+        .put(`/components/${this.component.id}`, payload)
+        .then(this.updateAdditionalQuestionsSuccess)
+        .catch(this.alertOrNotifyResponse);
+    },
+    updateAdditionalQuestionsSuccess: function (response) {
+      this.alertOrNotifyResponse(response);
+      this.$emit("componentUpdated");
+    },
+  },
+};
+</script>
+
+<style scoped></style>

--- a/app/javascript/components/components/ProjectComponent.vue
+++ b/app/javascript/components/components/ProjectComponent.vue
@@ -139,6 +139,37 @@
             </b-collapse>
           </b-col>
         </b-row>
+        <b-row>
+          <b-col>
+            <div class="clickable" @click="showAdditionalQuestions = !showAdditionalQuestions">
+              <h5 class="m-0 d-inline-block">Component Additional Questions</h5>
+
+              <i
+                v-if="showAdditionalQuestions"
+                class="mdi mdi-menu-down superVerticalAlign collapsableArrow"
+              />
+              <i
+                v-if="!showAdditionalQuestions"
+                class="mdi mdi-menu-up superVerticalAlign collapsableArrow"
+              />
+            </div>
+            <b-collapse id="collapse-metadata" v-model="showAdditionalQuestions">
+              <div
+                v-for="value in component.additional_questions"
+                :key="value.id + value.question_type + value.name"
+              >
+                <p v-linkified class="ml-2 mb-0 mt-2">
+                  <strong>{{ value.name }}: </strong>
+                  <template v-if="value.question_type === 'dropdown'">
+                    Options: {{ value.options.join(", ") }}
+                  </template>
+                  <template v-else> Freeform Text </template>
+                </p>
+              </div>
+              <AddQuestionsModal :component="component" @componentUpdated="refreshComponent" />
+            </b-collapse>
+          </b-col>
+        </b-row>
       </b-col>
     </b-row>
   </div>
@@ -156,6 +187,7 @@ import History from "../shared/History.vue";
 import RulesReadOnlyView from "../rules/RulesReadOnlyView.vue";
 import MembershipsTable from "../memberships/MembershipsTable.vue";
 import UpdateMetadataModal from "./UpdateMetadataModal.vue";
+import AddQuestionsModal from "./AddQuestionsModal.vue";
 
 export default {
   name: "Projectcomponent",
@@ -164,6 +196,7 @@ export default {
     RulesReadOnlyView,
     MembershipsTable,
     UpdateMetadataModal,
+    AddQuestionsModal,
   },
   mixins: [
     DateFormatMixinVue,
@@ -208,6 +241,7 @@ export default {
     return {
       showMetadata: true,
       showHistory: true,
+      showAdditionalQuestions: true,
       component: this.initialComponentState,
       componentTabIndex: 0,
     };

--- a/app/javascript/components/rules/RuleEditor.vue
+++ b/app/javascript/components/rules/RuleEditor.vue
@@ -65,7 +65,7 @@ export default {
     },
     additional_questions: {
       type: Array,
-      default: [],
+      default: () => [],
     },
   },
   data: function () {

--- a/app/javascript/components/rules/RuleEditor.vue
+++ b/app/javascript/components/rules/RuleEditor.vue
@@ -17,6 +17,7 @@
       :statuses="statuses"
       :severities="severities"
       :read-only="readOnly"
+      :additional_questions="additional_questions"
     />
 
     <BasicRuleForm
@@ -25,6 +26,7 @@
       :statuses="statuses"
       :severities_map="severities_map"
       :read-only="readOnly"
+      :additional_questions="additional_questions"
     />
   </div>
 </template>
@@ -60,6 +62,10 @@ export default {
     advanced_fields: {
       type: Boolean,
       default: false,
+    },
+    additional_questions: {
+      type: Array,
+      default: [],
     },
   },
   data: function () {

--- a/app/javascript/components/rules/RuleHistories.vue
+++ b/app/javascript/components/rules/RuleHistories.vue
@@ -15,6 +15,7 @@
     <b-collapse id="collapse-histories" v-model="showHistories">
       <History
         :histories="rule.histories"
+        :component="component"
         :rule="rule"
         :statuses="statuses"
         :severities="severities"
@@ -45,6 +46,10 @@ export default {
       type: Array,
       required: true,
     },
+    component: {
+      type: Object,
+      required: true
+    }
   },
   data: function () {
     return {

--- a/app/javascript/components/rules/RuleHistories.vue
+++ b/app/javascript/components/rules/RuleHistories.vue
@@ -48,8 +48,8 @@ export default {
     },
     component: {
       type: Object,
-      required: true
-    }
+      required: true,
+    },
   },
   data: function () {
     return {

--- a/app/javascript/components/rules/RuleRevertModal.vue
+++ b/app/javascript/components/rules/RuleRevertModal.vue
@@ -215,7 +215,7 @@ export default {
     DisaRuleDescriptionForm,
     CheckForm,
     CommentModal,
-    AdditionalQuestions
+    AdditionalQuestions,
   },
   mixins: [
     AlertMixinVue,
@@ -243,7 +243,7 @@ export default {
     },
     component: {
       type: Object,
-      required: true
+      required: true,
     },
   },
   data: function () {
@@ -294,9 +294,8 @@ export default {
           (e) => e.id == this.history.auditable_id
         );
       } else if (this.history.auditable_type == "AdditionalAnswer") {
-        dependentRecord["additional_answers_attributes"] = this.rule.additional_answers_attributes.filter(
-          (e) => e.id == this.history.auditable_id
-        )
+        dependentRecord["additional_answers_attributes"] =
+          this.rule.additional_answers_attributes.filter((e) => e.id == this.history.auditable_id);
       }
 
       let curState = _.cloneDeep(dependentRecord);
@@ -318,10 +317,10 @@ export default {
       this.history.audited_changes.forEach((audited_change) => {
         const audited_field = audited_change.field;
         if (this.selectedRevertFields.includes(audited_field)) {
-          if(this.history.auditable_type === 'AdditionalAnswer') {
+          if (this.history.auditable_type === "AdditionalAnswer") {
             let id = this.rule.additional_answers_attributes.findIndex(
               (e) => e.id == this.history.auditable_id
-            )
+            );
             afterState.additional_answers_attributes[id].answer = audited_change.prev_value;
           } else {
             afterState[audited_field] = audited_change.prev_value;

--- a/app/javascript/components/rules/RulesCodeEditorView.vue
+++ b/app/javascript/components/rules/RulesCodeEditorView.vue
@@ -33,6 +33,7 @@
               :severities="severities"
               :severities_map="severities_map"
               :advanced_fields="component.advanced_fields"
+              :additional_questions="component.additional_questions"
             />
           </div>
 
@@ -44,7 +45,7 @@
               :current-user-id="currentUserId"
             />
             <br />
-            <RuleHistories :rule="selectedRule()" :statuses="statuses" :severities="severities" />
+            <RuleHistories :rule="selectedRule()" :component="component" :statuses="statuses" :severities="severities" />
           </div>
         </div>
       </div>

--- a/app/javascript/components/rules/RulesCodeEditorView.vue
+++ b/app/javascript/components/rules/RulesCodeEditorView.vue
@@ -45,7 +45,12 @@
               :current-user-id="currentUserId"
             />
             <br />
-            <RuleHistories :rule="selectedRule()" :component="component" :statuses="statuses" :severities="severities" />
+            <RuleHistories
+              :rule="selectedRule()"
+              :component="component"
+              :statuses="statuses"
+              :severities="severities"
+            />
           </div>
         </div>
       </div>

--- a/app/javascript/components/rules/RulesReadOnlyView.vue
+++ b/app/javascript/components/rules/RulesReadOnlyView.vue
@@ -30,6 +30,7 @@
           :severities_map="severities_map"
           :read-only="true"
           :advanced_fields="component.advanced_fields"
+          :additional_questions="component.additional_questions"
         />
       </div>
     </template>

--- a/app/javascript/components/rules/forms/AdditionalAnswerForm.vue
+++ b/app/javascript/components/rules/forms/AdditionalAnswerForm.vue
@@ -44,23 +44,25 @@ export default {
     disabled: {
       type: Boolean,
       default: false,
-    }
+    },
   },
   methods: {
-    addOrUpdateAnswer: function(event, question_id) {
-      let all_answers = this.rule.additional_answers_attributes
-      let index = all_answers.findIndex(answer => answer.additional_question_id === question_id);
-      if(index !== -1) {
+    addOrUpdateAnswer: function (event, question_id) {
+      let all_answers = this.rule.additional_answers_attributes;
+      let index = all_answers.findIndex((answer) => answer.additional_question_id === question_id);
+      if (index !== -1) {
         all_answers[index].answer = event;
       } else {
-        all_answers.push({additional_question_id: question_id, answer: event});
+        all_answers.push({ additional_question_id: question_id, answer: event });
       }
 
-      this.$root.$emit('update:rule', { ...this.rule, additional_answers_attributes: all_answers })
+      this.$root.$emit("update:rule", { ...this.rule, additional_answers_attributes: all_answers });
     },
-    findAnswerText: function(question_id) {
-      return this.rule.additional_answers_attributes.find(element => element.additional_question_id == question_id)?.answer;
-    }
-  }
+    findAnswerText: function (question_id) {
+      return this.rule.additional_answers_attributes.find(
+        (element) => element.additional_question_id == question_id
+      )?.answer;
+    },
+  },
 };
 </script>

--- a/app/javascript/components/rules/forms/AdditionalAnswerForm.vue
+++ b/app/javascript/components/rules/forms/AdditionalAnswerForm.vue
@@ -1,0 +1,66 @@
+<template>
+  <div>
+    <label :for="`ruleEditor-additional-question-${question.name}`">
+      {{ question.name }}
+    </label>
+    <b-form-select
+      v-if="question.question_type === 'dropdown'"
+      :id="`ruleEditor-additional-field-${question.id}`"
+      :value="findAnswerText(question.id)"
+      :disabled="disabled"
+      :options="question.options"
+      :class="inputClass(question.name)"
+      @input="addOrUpdateAnswer($event, question.id)"
+    />
+    <b-form-textarea
+      v-else
+      :id="`ruleEditor-additional-field-${question.id}`"
+      :disabled="disabled"
+      :value="findAnswerText(question.id)"
+      placeholder=""
+      rows="1"
+      max-rows="99"
+      :class="inputClass(question.name)"
+      @input="addOrUpdateAnswer($event, question.id)"
+    />
+  </div>
+</template>
+
+<script>
+import FormFeedbackMixinVue from "../../../mixins/FormFeedbackMixin.vue";
+
+export default {
+  name: "AdditionalAnswerForm",
+  mixins: [FormFeedbackMixinVue],
+  props: {
+    rule: {
+      type: Object,
+      required: true,
+    },
+    question: {
+      type: Object,
+      required: true,
+    },
+    disabled: {
+      type: Boolean,
+      default: false,
+    }
+  },
+  methods: {
+    addOrUpdateAnswer: function(event, question_id) {
+      let all_answers = this.rule.additional_answers_attributes
+      let index = all_answers.findIndex(answer => answer.additional_question_id === question_id);
+      if(index !== -1) {
+        all_answers[index].answer = event;
+      } else {
+        all_answers.push({additional_question_id: question_id, answer: event});
+      }
+
+      this.$root.$emit('update:rule', { ...this.rule, additional_answers_attributes: all_answers })
+    },
+    findAnswerText: function(question_id) {
+      return this.rule.additional_answers_attributes.find(element => element.additional_question_id == question_id)?.answer;
+    }
+  }
+};
+</script>

--- a/app/javascript/components/rules/forms/AdditionalQuestions.vue
+++ b/app/javascript/components/rules/forms/AdditionalQuestions.vue
@@ -1,0 +1,43 @@
+<template>
+  <div>
+    <b-form-group
+      v-for="question in additional_questions"
+      :key="`additional-question-${question.id}`"
+    >
+      <AdditionalAnswerForm :rule="rule" :question="question" :disabled="disabled" :invalidFeedback="invalidFeedback" :validFeedback="validFeedback" />
+    </b-form-group>
+  </div>
+</template>
+
+<script>
+import AdditionalAnswerForm from "./AdditionalAnswerForm"
+
+export default {
+  name: "AdditionalQuestions",
+  components: { AdditionalAnswerForm },
+  props: {
+    rule: {
+      type: Object,
+      required: true,
+    },
+    additional_questions: {
+      type: Array,
+      default: [],
+    },
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+    validFeedback: {
+      type: Object,
+      required: false,
+    },
+    invalidFeedback: {
+      type: Object,
+      required: false,
+    },
+  },
+  methods: {
+  }
+};
+</script>

--- a/app/javascript/components/rules/forms/AdditionalQuestions.vue
+++ b/app/javascript/components/rules/forms/AdditionalQuestions.vue
@@ -4,13 +4,19 @@
       v-for="question in additional_questions"
       :key="`additional-question-${question.id}`"
     >
-      <AdditionalAnswerForm :rule="rule" :question="question" :disabled="disabled" :invalidFeedback="invalidFeedback" :validFeedback="validFeedback" />
+      <AdditionalAnswerForm
+        :rule="rule"
+        :question="question"
+        :disabled="disabled"
+        :invalid-feedback="invalidFeedback"
+        :valid-feedback="validFeedback"
+      />
     </b-form-group>
   </div>
 </template>
 
 <script>
-import AdditionalAnswerForm from "./AdditionalAnswerForm"
+import AdditionalAnswerForm from "./AdditionalAnswerForm";
 
 export default {
   name: "AdditionalQuestions",
@@ -22,7 +28,7 @@ export default {
     },
     additional_questions: {
       type: Array,
-      default: [],
+      default: () => [],
     },
     disabled: {
       type: Boolean,
@@ -37,7 +43,6 @@ export default {
       required: false,
     },
   },
-  methods: {
-  }
+  methods: {},
 };
 </script>

--- a/app/javascript/components/rules/forms/AdvancedRuleForm.vue
+++ b/app/javascript/components/rules/forms/AdvancedRuleForm.vue
@@ -204,6 +204,11 @@ export default {
     disabled: function () {
       return this.readOnly || this.rule.locked || this.rule.review_requestor_id ? true : false;
     },
+    // Still allow additional questions to be edited except when the control is actually
+    // locked, or if a review is requested or this is a read only view.
+    forceEnableAdditionalQuestions: function () {
+      return !this.readOnly && !this.rule.locked && !this.rule.review_requestor_id;
+    },
     // The fields to show need to be dynamic based on the rule status
     ruleFormFields: function () {
       if (this.rule.satisfied_by.length > 0 || this.rule.status == "Applicable - Configurable") {

--- a/app/javascript/components/rules/forms/AdvancedRuleForm.vue
+++ b/app/javascript/components/rules/forms/AdvancedRuleForm.vue
@@ -190,7 +190,7 @@ export default {
     },
     additional_questions: {
       type: Array,
-      default: [],
+      default: () => [],
     },
   },
   data: function () {

--- a/app/javascript/components/rules/forms/AdvancedRuleForm.vue
+++ b/app/javascript/components/rules/forms/AdvancedRuleForm.vue
@@ -7,6 +7,7 @@
         :severities="severities"
         :disabled="disabled"
         :fields="ruleFormFields"
+        :additional_questions="additional_questions"
       />
 
       <!-- rule_descriptions -->
@@ -186,6 +187,10 @@ export default {
     readOnly: {
       type: Boolean,
       default: false,
+    },
+    additional_questions: {
+      type: Array,
+      default: [],
     },
   },
   data: function () {

--- a/app/javascript/components/rules/forms/BasicRuleForm.vue
+++ b/app/javascript/components/rules/forms/BasicRuleForm.vue
@@ -9,6 +9,7 @@
         :fields="ruleFormFields"
         :disa_fields="disaDescriptionFormFields"
         :check_fields="checkFormFields"
+        :force_enable_additional_questions="forceEnableAdditionalQuestions"
         :additional_questions="additional_questions"
       />
     </b-form>
@@ -69,6 +70,11 @@ export default {
         this.rule.review_requestor_id
         ? true
         : false;
+    },
+    // Still allow additional questions to be edited except when the control is actually
+    // locked, or if a review is requested or this is a read only view.
+    forceEnableAdditionalQuestions: function () {
+      return !this.readOnly && !this.rule.locked && !this.rule.review_requestor_id;
     },
     // The fields to show need to be dynamic based on the rule status
     ruleFormFields: function () {

--- a/app/javascript/components/rules/forms/BasicRuleForm.vue
+++ b/app/javascript/components/rules/forms/BasicRuleForm.vue
@@ -9,6 +9,7 @@
         :fields="ruleFormFields"
         :disa_fields="disaDescriptionFormFields"
         :check_fields="checkFormFields"
+        :additional_questions="additional_questions"
       />
     </b-form>
 
@@ -54,6 +55,10 @@ export default {
     readOnly: {
       type: Boolean,
       default: false,
+    },
+    additional_questions: {
+      type: Array,
+      default: [],
     },
   },
   computed: {

--- a/app/javascript/components/rules/forms/BasicRuleForm.vue
+++ b/app/javascript/components/rules/forms/BasicRuleForm.vue
@@ -58,7 +58,7 @@ export default {
     },
     additional_questions: {
       type: Array,
-      default: [],
+      default: () => [],
     },
   },
   computed: {

--- a/app/javascript/components/rules/forms/CheckForm.vue
+++ b/app/javascript/components/rules/forms/CheckForm.vue
@@ -136,10 +136,6 @@ export default {
   mixins: [FormFeedbackMixinVue],
   // `rule` and `index` are necessary if edits are to be made
   props: {
-    check: {
-      type: Object,
-      required: true,
-    },
     rule: {
       type: Object,
     },
@@ -171,6 +167,12 @@ export default {
         content: "Describe how to check for the presence of the vulnerability",
       },
     };
+  },
+  computed: {
+    check: function () {
+      return (this.rule.satisfied_by.length > 0 ? this.rule.satisfied_by[0] : this.rule)
+        .checks_attributes[0];
+    },
   },
 };
 </script>

--- a/app/javascript/components/rules/forms/RuleForm.vue
+++ b/app/javascript/components/rules/forms/RuleForm.vue
@@ -176,9 +176,8 @@
         <!-- checks -->
         <CheckForm
           v-if="rule.status == 'Applicable - Configurable' && rule.checks_attributes.length >= 1"
-          :rule="rule.satisfied_by.length > 0 ? rule.satisfied_by[0] : rule"
+          :rule="rule"
           :index="0"
-          :check="rule.checks_attributes[0]"
           :disabled="disabled"
           :fields="check_fields"
         />
@@ -456,7 +455,7 @@
 
       <AdditionalQuestions
         :additional_questions="additional_questions"
-        :disabled="disabled"
+        :disabled="disabled && !force_enable_additional_questions"
         :rule="rule"
       />
     </b-form>
@@ -489,6 +488,10 @@ export default {
     disabled: {
       type: Boolean,
       required: true,
+    },
+    force_enable_additional_questions: {
+      type: Boolean,
+      default: false,
     },
     disa_fields: {
       type: Object,

--- a/app/javascript/components/rules/forms/RuleForm.vue
+++ b/app/javascript/components/rules/forms/RuleForm.vue
@@ -454,7 +454,11 @@
         </b-form-invalid-feedback>
       </b-form-group>
 
-      <AdditionalQuestions :additional_questions="additional_questions" :disabled="disabled" :rule="rule" />
+      <AdditionalQuestions
+        :additional_questions="additional_questions"
+        :disabled="disabled"
+        :rule="rule"
+      />
     </b-form>
   </div>
 </template>
@@ -494,7 +498,7 @@ export default {
     },
     additional_questions: {
       type: Array,
-      default: [],
+      default: () => [],
     },
     fields: {
       type: Object,

--- a/app/javascript/components/rules/forms/RuleForm.vue
+++ b/app/javascript/components/rules/forms/RuleForm.vue
@@ -453,6 +453,8 @@
           {{ invalidFeedback["vendor_comments"] }}
         </b-form-invalid-feedback>
       </b-form-group>
+
+      <AdditionalQuestions :additional_questions="additional_questions" :disabled="disabled" :rule="rule" />
     </b-form>
   </div>
 </template>
@@ -460,11 +462,12 @@
 <script>
 import FormFeedbackMixinVue from "../../../mixins/FormFeedbackMixin.vue";
 import DisaRuleDescriptionForm from "./DisaRuleDescriptionForm";
+import AdditionalQuestions from "./AdditionalQuestions";
 import CheckForm from "./CheckForm";
 
 export default {
   name: "RuleForm",
-  components: { DisaRuleDescriptionForm, CheckForm },
+  components: { DisaRuleDescriptionForm, CheckForm, AdditionalQuestions },
   mixins: [FormFeedbackMixinVue],
   props: {
     rule: {
@@ -488,6 +491,10 @@ export default {
     },
     check_fields: {
       type: Object,
+    },
+    additional_questions: {
+      type: Array,
+      default: [],
     },
     fields: {
       type: Object,

--- a/app/javascript/components/shared/History.vue
+++ b/app/javascript/components/shared/History.vue
@@ -72,8 +72,8 @@ export default {
     },
     component: {
       type: Object,
-      required: false
-    }
+      required: false,
+    },
   },
   methods: {
     userIdentifier: function (history) {

--- a/app/javascript/components/shared/History.vue
+++ b/app/javascript/components/shared/History.vue
@@ -14,6 +14,7 @@
         <template v-if="revertable">
           <RuleRevertModal
             :rule="rule"
+            :component="component"
             :history="history"
             :statuses="statuses"
             :severities="severities"
@@ -69,6 +70,10 @@ export default {
       type: Boolean,
       default: true,
     },
+    component: {
+      type: Object,
+      required: false
+    }
   },
   methods: {
     userIdentifier: function (history) {
@@ -90,7 +95,16 @@ export default {
       if (changes.field == "admin") {
         return `was ${changes.new_value ? "promoted to" : "demoted from"} admin`;
       } else {
-        return `${changes.field} was updated from ${changes.prev_value} to ${changes.new_value}`;
+        return `${changes.field} was updated from ${this.prettifyObjects(
+          changes.prev_value
+        )} to ${this.prettifyObjects(changes.new_value)}`;
+      }
+    },
+    prettifyObjects: function (value) {
+      if (typeof value === "object") {
+        return JSON.stringify(value, null, 4);
+      } else {
+        return value;
       }
     },
     computeDeletionText: function (history) {

--- a/app/javascript/mixins/HumanizedTypesMixIn.vue
+++ b/app/javascript/mixins/HumanizedTypesMixIn.vue
@@ -4,6 +4,8 @@ export default {
   data: function () {
     return {
       humanizedTypes: {
+        AdditionalAnswer: "Additional Answer",
+        AdditionalQuestion: "Additional Question",
         BaseRule: "Rule",
         RuleDescription: "Rule Description",
         DisaRuleDescription: "Rule Description",

--- a/app/lib/vulcan_audit.rb
+++ b/app/lib/vulcan_audit.rb
@@ -48,11 +48,23 @@ class VulcanAudit < ::Audited::Audit
         # On creation, the `audited_value` will be a single value (i.e. not an Array)
         # After an edit, the `audited_value` will be an Array where `[0]` is prev and `[1]` is new
         {
-          field: audited_field,
+          field: format_audited_field(audited_field),
           prev_value: (audited_value.is_a?(Array) ? audited_value[0] : nil),
           new_value: (audited_value.is_a?(Array) ? audited_value[1] : audited_value)
         }
       end
     }
+  end
+
+  private
+
+  # AdditionalAnswers are a special case where the field value is not the field
+  # that changed but rather the name of the associated additional_question.
+  def format_audited_field(field)
+    if auditable_type.eql?('AdditionalAnswer') && field.eql?('answer')
+      return auditable.additional_question.name
+    end
+
+    field
   end
 end

--- a/app/lib/vulcan_audit.rb
+++ b/app/lib/vulcan_audit.rb
@@ -61,9 +61,7 @@ class VulcanAudit < ::Audited::Audit
   # AdditionalAnswers are a special case where the field value is not the field
   # that changed but rather the name of the associated additional_question.
   def format_audited_field(field)
-    if auditable_type.eql?('AdditionalAnswer') && field.eql?('answer')
-      return auditable.additional_question.name
-    end
+    return auditable.additional_question.name if auditable_type.eql?('AdditionalAnswer') && field.eql?('answer')
 
     field
   end

--- a/app/models/additional_answer.rb
+++ b/app/models/additional_answer.rb
@@ -4,6 +4,8 @@
 class AdditionalAnswer < ApplicationRecord
   audited only: %i[answer], associated_with: :rule, max_audits: 1000
 
+  validates :additional_question_id, uniqueness: { scope: :rule_id }
+
   belongs_to :additional_question
   belongs_to :rule
 end

--- a/app/models/additional_answer.rb
+++ b/app/models/additional_answer.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# These are additional answers for the additional questions on a specific component
+class AdditionalAnswer < ApplicationRecord
+  audited only: %i[answer], associated_with: :rule, max_audits: 1000
+
+  belongs_to :additional_question
+  belongs_to :rule
+end

--- a/app/models/additional_question.rb
+++ b/app/models/additional_question.rb
@@ -3,6 +3,10 @@
 # These are additional questions on a component which users must fill out
 # for rules on that component
 class AdditionalQuestion < ApplicationRecord
+  amoeba do
+    include_association :additional_answers
+  end
+
   audited except: %i[component_id created_at updated_at], associated_with: :component, max_audits: 1000
 
   FIELD_TYPES = %w[dropdown freeform]

--- a/app/models/additional_question.rb
+++ b/app/models/additional_question.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# These are additional questions on a component which users must fill out
+# for rules on that component
+class AdditionalQuestion < ApplicationRecord
+  audited except: %i[component_id created_at updated_at], associated_with: :component, max_audits: 1000
+
+  FIELD_TYPES = %w[dropdown freeform]
+
+  enum question_type: FIELD_TYPES.zip(FIELD_TYPES).to_h
+
+  validates :name, :question_type, presence: true
+
+  validates :options, presence: true, if: -> { question_type.eql?(:dropdown) }
+
+  validates :name, uniqueness: { scope: :component_id }
+
+  belongs_to :component
+
+  has_many :additional_answers, dependent: :destroy
+end

--- a/app/models/additional_question.rb
+++ b/app/models/additional_question.rb
@@ -9,7 +9,7 @@ class AdditionalQuestion < ApplicationRecord
 
   audited except: %i[component_id created_at updated_at], associated_with: :component, max_audits: 1000
 
-  FIELD_TYPES = %w[dropdown freeform]
+  FIELD_TYPES = %w[dropdown freeform].freeze
 
   enum question_type: FIELD_TYPES.zip(FIELD_TYPES).to_h
 

--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -8,8 +8,19 @@ class Component < ApplicationRecord
 
   amoeba do
     include_association :rules
+    include_association :additional_questions
     set released: false
     set rules_count: 0
+
+    # There is unfortunately no way to do this at a lower level since the new component isn't
+    # accessible until amoeba is processing at this level
+    customize(lambda { |original_component, new_component|
+      new_component.additional_questions.each do |question|
+        question.additional_answers.each do |answer|
+          answer.rule = new_component.rules.find { |r| r.rule_id == answer.rule.rule_id }
+        end
+      end
+    })
   end
 
   audited except: %i[id admin_name admin_email memberships_count created_at updated_at], max_audits: 1000

--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -13,6 +13,7 @@ class Component < ApplicationRecord
   end
 
   audited except: %i[id admin_name admin_email memberships_count created_at updated_at], max_audits: 1000
+  has_associated_audits
 
   belongs_to :project, inverse_of: :components
   belongs_to :based_on,
@@ -28,7 +29,9 @@ class Component < ApplicationRecord
   has_many :memberships, -> { includes :user }, inverse_of: :membership, as: :membership, dependent: :destroy
   has_one :component_metadata, dependent: :destroy
 
-  accepts_nested_attributes_for :rules, :component_metadata
+  has_many :additional_questions, dependent: :destroy
+
+  accepts_nested_attributes_for :rules, :component_metadata, :additional_questions, allow_destroy: true
 
   after_create :import_srg_rules
 
@@ -40,7 +43,7 @@ class Component < ApplicationRecord
            :cannot_overlay_self
 
   def as_json(options = {})
-    methods = (options[:methods] || []) + %i[releasable]
+    methods = (options[:methods] || []) + %i[releasable additional_questions]
     super(options.merge(methods: methods)).merge(
       {
         based_on_title: based_on.title,

--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -14,7 +14,7 @@ class Component < ApplicationRecord
 
     # There is unfortunately no way to do this at a lower level since the new component isn't
     # accessible until amoeba is processing at this level
-    customize(lambda { |original_component, new_component|
+    customize(lambda { |_original_component, new_component|
       new_component.additional_questions.each do |question|
         question.additional_answers.each do |answer|
           answer.rule = new_component.rules.find { |r| r.rule_id == answer.rule.rule_id }

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -5,7 +5,6 @@
 class Rule < BaseRule
   amoeba do
     include_association :rule_descriptions
-    include_association :additional_answers
     include_association :disa_rule_descriptions
     include_association :checks
     include_association :references

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -56,7 +56,9 @@ class Rule < BaseRule
                                                      'vendor_comments', 'rule_id', 'review_requestor_id',
                                                      'component_id', 'changes_requested', 'srg_rule_id',
                                                      'security_requirements_guide_id'),
-        additional_answers_attributes: additional_answers.as_json.map { |c| c.except('rule_id', 'created_at', 'updated_at') },
+        additional_answers_attributes: additional_answers.as_json.map do |c|
+                                         c.except('rule_id', 'created_at', 'updated_at')
+                                       end
       }
     )
   end
@@ -83,29 +85,26 @@ class Rule < BaseRule
 
       fields.each do |field|
         # The only field we can revert on AdditionalAnswers is answer
-        field = 'answer' if audit.auditable_type.eql?("AdditionalAnswer")
+        field = 'answer' if audit.auditable_type.eql?('AdditionalAnswer')
 
         unless audit.audited_changes.include?(field)
           raise(RuleRevertError, "Field to revert (#{field.humanize}) does not exist in this history.")
         end
 
-
-
         # The audited change can either be an array `[prev_val, new_val]`
         # or just the `val`
         value = if audit.audited_changes[field].is_a?(Array)
-                          audit.audited_changes[field][0]
-                        else
-                          audit.audited_changes[field]
-                        end
+                  audit.audited_changes[field][0]
+                else
+                  audit.audited_changes[field]
+                end
 
         # Special case for AdditionalAnswer since it stores in the 'answer' field always
-        if audit.auditable_type.eql?("AdditionalAnswer")
+        if audit.auditable_type.eql?('AdditionalAnswer')
           record.answer = value
         else
           record[field] = value
         end
-
       end
       record.audit_comment = audit_comment if record.changed?
       record.save

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -61,6 +61,10 @@ class Rule < BaseRule
     satisfied_by.size.positive? ? 'Applicable - Configurable' : self[:status]
   end
 
+  def status=(value)
+    super(value) unless satisfied_by.size.positive?
+  end
+
   ##
   # Override `as_json` to include parent SRG information
   #

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -56,6 +56,11 @@ class Rule < BaseRule
     rule
   end
 
+  # Overrides for satisfied controls
+  def status
+    satisfied_by.size.positive? ? 'Applicable - Configurable' : self[:status]
+  end
+
   ##
   # Override `as_json` to include parent SRG information
   #
@@ -71,7 +76,7 @@ class Rule < BaseRule
                                                        'component_id', 'changes_requested', 'srg_rule_id',
                                                        'security_requirements_guide_id'),
           satisfies: satisfies.as_json(only: %i[id rule_id], skip_merge: true),
-          satisfied_by: satisfied_by.as_json(only: %i[id rule_id], skip_merge: true),
+          satisfied_by: satisfied_by.as_json(only: %i[id fixtext rule_id], skip_merge: true),
           additional_answers_attributes: additional_answers.as_json.map do |c|
                                            c.except('rule_id', 'created_at', 'updated_at')
                                          end
@@ -162,9 +167,9 @@ class Rule < BaseRule
       disa_rule_descriptions.first.vuln_discussion,
       status,
       srg_rule.checks.first.content, # original SRG check content
-      checks.first.content,
+      export_checktext,
       srg_rule.fixtext, # original SRG fix text
-      fixtext,
+      export_fixtext,
       status_justification,
       disa_rule_descriptions.first.mitigations,
       artifact_description,
@@ -173,6 +178,14 @@ class Rule < BaseRule
   end
 
   private
+
+  def export_fixtext
+    satisfied_by.size.positive? ? satisfied_by.first.fixtext : fixtext
+  end
+
+  def export_checktext
+    satisfied_by.size.positive? ? satisfied_by.first.checks.first.content : checks.first.content
+  end
 
   def vendor_comments_with_satisfactions
     comments = []

--- a/db/migrate/20211108210022_create_additional_questions.rb
+++ b/db/migrate/20211108210022_create_additional_questions.rb
@@ -5,6 +5,7 @@ class CreateAdditionalQuestions < ActiveRecord::Migration[6.1]
       t.string :question_type, null: false
       t.string :options, array: true, default: []
       t.references :component, index: true
+      t.index [:component_id, :name], unique: true
       t.timestamps
     end
   end

--- a/db/migrate/20211108210022_create_additional_questions.rb
+++ b/db/migrate/20211108210022_create_additional_questions.rb
@@ -1,0 +1,11 @@
+class CreateAdditionalQuestions < ActiveRecord::Migration[6.1]
+  def change
+    create_table :additional_questions do |t|
+      t.string :name, null: false
+      t.string :question_type, null: false
+      t.string :options, array: true, default: []
+      t.references :component, index: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20211109212911_create_additional_answers.rb
+++ b/db/migrate/20211109212911_create_additional_answers.rb
@@ -1,0 +1,11 @@
+class CreateAdditionalAnswers < ActiveRecord::Migration[6.1]
+  def change
+    create_table :additional_answers do |t|
+      t.references :rule, null: false, foreign_key: { to_table: :base_rules }
+      t.references :additional_question, null: false, foreign_key: true
+      t.text :answer
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20211109212911_create_additional_answers.rb
+++ b/db/migrate/20211109212911_create_additional_answers.rb
@@ -5,6 +5,8 @@ class CreateAdditionalAnswers < ActiveRecord::Migration[6.1]
       t.references :additional_question, null: false, foreign_key: true
       t.text :answer
 
+      t.index [:rule_id, :additional_question_id], unique: true
+
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 2021_11_09_212911) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["additional_question_id"], name: "index_additional_answers_on_additional_question_id"
+    t.index ["rule_id", "additional_question_id"], name: "index_additional_answers_on_rule_id_and_additional_question_id", unique: true
     t.index ["rule_id"], name: "index_additional_answers_on_rule_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,30 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_01_152514) do
+ActiveRecord::Schema.define(version: 2021_11_09_212911) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "additional_answers", force: :cascade do |t|
+    t.bigint "rule_id", null: false
+    t.bigint "additional_question_id", null: false
+    t.text "answer"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["additional_question_id"], name: "index_additional_answers_on_additional_question_id"
+    t.index ["rule_id"], name: "index_additional_answers_on_rule_id"
+  end
+
+  create_table "additional_questions", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "question_type", null: false
+    t.string "options", default: [], array: true
+    t.bigint "component_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["component_id"], name: "index_additional_questions_on_component_id"
+  end
 
   create_table "audits", force: :cascade do |t|
     t.integer "auditable_id"
@@ -230,6 +250,8 @@ ActiveRecord::Schema.define(version: 2021_11_01_152514) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "additional_answers", "additional_questions"
+  add_foreign_key "additional_answers", "base_rules", column: "rule_id"
   add_foreign_key "base_rules", "base_rules", column: "srg_rule_id"
   add_foreign_key "base_rules", "components"
   add_foreign_key "base_rules", "security_requirements_guides"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -32,6 +32,7 @@ ActiveRecord::Schema.define(version: 2021_11_09_212911) do
     t.bigint "component_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["component_id", "name"], name: "index_additional_questions_on_component_id_and_name", unique: true
     t.index ["component_id"], name: "index_additional_questions_on_component_id"
   end
 


### PR DESCRIPTION
This adds the ability for users to add arbitrary fields on the component which are then available to be filled out on the individual rules. As of right now they are not available in any export however they do properly revert.