### PR TITLE
Better error handling and fixes for import

### DIFF
--- a/app/constants/import_constants.rb
+++ b/app/constants/import_constants.rb
@@ -15,7 +15,8 @@ module ImportConstants
   }.freeze
 
   OPTIONAL_MAPPING_CONSTANTS = {
-    vendor_comments: 'Vendor Comments'
+    vendor_comments: 'Vendor Comments',
+    mitigation: 'Mitigation'
   }.freeze
 
   IMPORT_MAPPING = REQUIRED_MAPPING_CONSTANTS.merge(OPTIONAL_MAPPING_CONSTANTS)

--- a/app/models/base_rule.rb
+++ b/app/models/base_rule.rb
@@ -43,8 +43,8 @@ class BaseRule < ApplicationRecord
     rule = rule_class.new(
       rule_id: rule_mapping.id,
       status: rule_mapping.status.first&.status || 'Not Yet Determined',
-      rule_severity: rule_mapping.severity || nil,
-      rule_weight: rule_mapping.weight || nil,
+      rule_severity: rule_mapping.severity || 'medium',
+      rule_weight: rule_mapping.weight || '10.0',
       version: rule_mapping.version.first&.version,
       title: rule_mapping.title.first || nil,
       ident: rule_mapping.ident.reject(&:legacy).first.ident,

--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -128,13 +128,15 @@ class Component < ApplicationRecord
       r.status = status_index ? STATUSES[status_index] : STATUSES[0]
       # Severities are provided in the spreadsheet in the form CAT I II or III, however they are
       # stored in vulcan in 'low', 'medium', 'high'. If the spreadsheet value cannot be mapped then
-      # fall back to the default from the SRG
-      severity = SEVERITIES_MAP.invert[row[IMPORT_MAPPING[:rule_severity]].upcase]
+      # fall back to the default from the SRG. Since this is a clone of an SRGRule, by not setting
+      # anything the value from the SRGRule will be propagated to this rule.
+      severity = SEVERITIES_MAP.invert[row[IMPORT_MAPPING[:rule_severity]]&.upcase]
       r.rule_severity = severity if severity
       r.srg_rule_id = srg_rule.id
 
       disa_rule_description = r.disa_rule_descriptions.first
       disa_rule_description.vuln_discussion = row[IMPORT_MAPPING[:vuln_discussion]]
+      disa_rule_description.mitigations = row[IMPORT_MAPPING[:mitigation]]
 
       check = r.checks.first
       check.content = row[IMPORT_MAPPING[:check_content]]

--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -124,7 +124,7 @@ class Component < ApplicationRecord
       r.status_justification = row[IMPORT_MAPPING[:status_justification]]
       r.vendor_comments = row[IMPORT_MAPPING[:vendor_comments]]
       # Get status with the case ignored. If none is found then fall back to the default status
-      status_index = STATUSES.find_index { |item| item.casecmp(row[IMPORT_MAPPING[:status]]).zero? }
+      status_index = STATUSES.find_index { |item| item.casecmp(row[IMPORT_MAPPING[:status]])&.zero? }
       r.status = status_index ? STATUSES[status_index] : STATUSES[0]
       # Severities are provided in the spreadsheet in the form CAT I II or III, however they are
       # stored in vulcan in 'low', 'medium', 'high'. If the spreadsheet value cannot be mapped then

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -231,6 +231,9 @@ class Rule < BaseRule
   # Rules should never be deleted if they are under review or locked
   # This checks *_was to cover the case where an attrubute was changed before attempting to destroy
   def prevent_destroy_if_under_review_or_locked
+    # Allow deletion if it is due to the parent being deleted
+    return if destroyed_by_association.present?
+
     # Abort if under review and trying to delete
     if review_requestor_id_was.present?
       errors.add(:base, 'Control is under review and cannot be destroyed')

--- a/app/models/security_requirements_guide.rb
+++ b/app/models/security_requirements_guide.rb
@@ -69,16 +69,12 @@ class SecurityRequirementsGuide < ApplicationRecord
     end
 
     # Examine import results for failures
-    success = SrgRule.import(srg_rules, all_or_none: true, recursive: true).failed_instances.blank?
-    if success
+    failures = SrgRule.import(srg_rules, all_or_none: true, recursive: true).failed_instances
+    if failures.empty?
       reload
     else
       errors.add(:base, 'Some rules failed to import successfully for the SRG.')
+      raise ActiveRecord::Rollback
     end
-    success
-  rescue StandardError => e
-    message = e.message.truncate(50)
-    errors.add(:base, "Encountered an error when importing rules to the SRG: #{message}")
-    false
   end
 end


### PR DESCRIPTION
Provide better defaults for severity and weight
Undo save if the rules associated with a security requirements guide fail to import. This protects from bad SRGs saving to the database.
Allow components to be destroyed even if they have locked rules in them.
Include mitigations and handle blank severity mappings more gracefully
Show better errors to administrators on 500 errors across the application