### PR TITLE
VULCAN 361: Fix overlaid components

### DIFF
--- a/app/controllers/components_controller.rb
+++ b/app/controllers/components_controller.rb
@@ -117,6 +117,8 @@ class ComponentsController < ApplicationController
                          new_release: component_create_params[:release],
                          new_title: component_create_params[:title],
                          new_description: component_create_params[:description])
+    elsif component_create_params[:component_id]
+      Component.find(component_create_params[:component_id]).overlay(@project.id)
     elsif component_create_params[:file]
       # Create a new component from the provided parameters and then pass the spreadsheet
       # to the component for further parsing
@@ -124,7 +126,7 @@ class ComponentsController < ApplicationController
       component.from_spreadsheet(component_create_params[:file])
       component
     else
-      Component.new(component_create_params.except(:id, :duplicate, :file).merge({ project: @project }))
+      Component.new(component_create_params.except(:id, :duplicate, :component_id, :file).merge({ project: @project }))
     end
   end
 
@@ -159,6 +161,7 @@ class ComponentsController < ApplicationController
     params.require(:component).permit(
       :id,
       :duplicate,
+      :component_id,
       :security_requirements_guide_id,
       :name,
       :prefix,

--- a/app/javascript/components/components/AddComponentModal.vue
+++ b/app/javascript/components/components/AddComponentModal.vue
@@ -16,6 +16,12 @@
     >
       <!-- Searchable projects -->
       <b-form v-if="!selectedComponent" @submit="addComponent()">
+        <input
+          id="AddComponentAuthenticityToken"
+          type="hidden"
+          name="authenticity_token"
+          :value="authenticityToken"
+        />
         <b-row>
           <b-col class="d-flex">
             <b-input-group>
@@ -120,13 +126,6 @@ export default {
       let payload = {
         component: {
           component_id: this.selectedComponent.id,
-          prefix: this.selectedComponent.prefix,
-          security_requirements_guide_id: this.selectedComponent.security_requirements_guide_id,
-          name: this.selectedComponent.name,
-          version: this.selectedComponent.version,
-          release: this.selectedComponent.release,
-          title: this.selectedComponent.title,
-          description: this.selectedComponent.description,
         },
       };
 

--- a/app/javascript/components/components/ComponentCard.vue
+++ b/app/javascript/components/components/ComponentCard.vue
@@ -23,7 +23,7 @@
         <i v-if="component.released" class="mdi mdi-stamper h5" aria-hidden="true" />
         <!-- Rules count info -->
         <span class="float-right h6">
-          {{ component.rules_count }} {{ component.component_id ? "Overlayed" : "" }} Controls
+          {{ component.rules_count }} {{ component.component_id ? "Overlaid" : "" }} Controls
         </span>
       </b-card-title>
       <b-card-sub-title class="mb-2">

--- a/app/javascript/components/project/Project.vue
+++ b/app/javascript/components/project/Project.vue
@@ -59,7 +59,7 @@
               </b-col>
             </b-row>
 
-            <h2>Overlayed Components</h2>
+            <h2>Overlaid Components</h2>
             <AddComponentModal
               v-if="role_gte_to(effective_permissions, 'admin')"
               :project_id="project.id"

--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -10,6 +10,7 @@ class Component < ApplicationRecord
   attr_accessor :skip_import_srg_rules
 
   amoeba do
+    include_association :component_metadata
     include_association :rules
     include_association :additional_questions
     set released: false
@@ -230,6 +231,13 @@ class Component < ApplicationRecord
     new_component.title = new_title if new_title
     new_component.description = new_description if new_description
     new_component.skip_import_srg_rules = true
+    new_component
+  end
+
+  def overlay(project_id)
+    new_component = amoeba_dup
+    new_component.project_id = project_id
+    new_component.component_id = id
     new_component
   end
 

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -7,6 +7,8 @@ class Rule < BaseRule
     # Using set review_requestor_id: nil does not work as expected, must use nullify
     nullify :review_requestor_id
     set locked: false
+
+    include_association :additional_answers
   end
 
   audited except: %i[component_id review_requestor_id created_at updated_at locked], max_audits: 1000

--- a/db/migrate/20211007162847_make_components_child_to_single_project.rb
+++ b/db/migrate/20211007162847_make_components_child_to_single_project.rb
@@ -4,7 +4,7 @@ class MakeComponentsChildToSingleProject < ActiveRecord::Migration[6.1]
     remove_index :components, name: :components_parent_child_id_index
     remove_column :components, :child_project_id, :bigint
 
-    # Allow a component to reference another component so that it can be overlayed
+    # Allow a component to reference another component so that it can be overlaid
     add_reference :components, :component, foreign_key: true
   end
 end

--- a/spec/models/rules_spec.rb
+++ b/spec/models/rules_spec.rb
@@ -39,13 +39,13 @@ RSpec.describe Review, type: :model do
     )
   end
 
-  # context 'overlayed rules are delegated to overlayed components' do
+  # context 'overlaid rules are delegated to overlaid components' do
   #   it 'properly collects all rule information into one rule' do
   #     # Create a component overlay of `p2_c1 overlays p1_c1`
   #     @p2_c1 = Component.create(project: @p2, version: 'Photon OS 3.1 V1R1', prefix: 'PHOS-03')
   #     # Pick a rule to overlay
   #     rule_to_overlay = @p1_c1.rules.first
-  #     # Create the overlayed version - connected via rule_id
+  #     # Create the overlaid version - connected via rule_id
   #     new_rule = Rule.create(component: @p2_c1, rule_id: rule_to_overlay.rule_id)
   #     # Verify that a field we will modify is currently nil
   #     expect(new_rule.status).to eq(nil)
@@ -55,7 +55,7 @@ RSpec.describe Review, type: :model do
   #     # Verify that the new_rule has no checks or disa descriptions
   #     expect(new_rule.checks.size).to eq(0)
   #     expect(new_rule.disa_rule_descriptions.size).to eq(0)
-  #     # Verify that the overlayed rule has the right number of checks and disa descriptions
+  #     # Verify that the overlaid rule has the right number of checks and disa descriptions
   #     expect(new_rule.overlay_rule.checks.size).not_to eq(0)
   #     expect(new_rule.overlay_rule.disa_rule_descriptions.size).not_to eq(0)
   #     expect(new_rule.overlay_rule.checks.size).to eq(rule_to_overlay.checks.size)


### PR DESCRIPTION
Contains the following changes:
- released component info such as control status, check/fix text, status justifications, etc. are now copied over
- overlaid components should now show up under overlaid components instead of with the non-overlaid ones
- changed all instances of "overlayed" to "overlaid"

Reviews and histories are not copied over because they are stored in the db quite differently than the rest of the data. This might be doable, but would require more intricate work and if it's not necessary for now, we can maybe come back to it after we prioritize other important issues

Closes: https://github.com/mitre/vulcan/issues/361