### PR TITLE
VULCAN-452: Review workflow improvements

### DIFF
--- a/app/javascript/components/components/ProjectComponent.vue
+++ b/app/javascript/components/components/ProjectComponent.vue
@@ -242,7 +242,7 @@
         <b-row>
           <b-col>
             <div v-if="selectedRule.reviews">
-              <RuleReviews :rule="selectedRule" :read-only="true" />
+              <RuleReviews :rule="selectedRule" />
               <br />
             </div>
             <div v-if="selectedRule.histories">

--- a/app/javascript/components/rules/RuleEditorHeader.vue
+++ b/app/javascript/components/rules/RuleEditorHeader.vue
@@ -35,7 +35,7 @@
           :selected-rule-text="`${projectPrefix}-${rule.rule_id}`"
           @ruleSelected="$emit('ruleSelected', $event.id)"
         />
-        <b-button v-b-modal.duplicate-rule-modal variant="primary">Clone Control</b-button>
+        <b-button v-b-modal.duplicate-rule-modal variant="info">Clone Control</b-button>
         <!-- Mark/Unmark as duplicate modal -->
         <span
           v-if="
@@ -47,7 +47,7 @@
           v-b-tooltip.hover
           title="This control cannot be marked as duplicate because it satisfies other controls"
         >
-          <b-button v-b-modal.mark-as-duplicate-modal disabled variant="info"
+          <b-button v-b-modal.mark-as-duplicate-modal disabled variant="warning"
             >Mark as Duplicate</b-button
           >
         </span>
@@ -60,7 +60,7 @@
               rule.satisfies.length === 0
             "
             v-b-modal.mark-rule-as-duplicate-modal
-            variant="info"
+            variant="warning"
             >Mark as Duplicate</b-button
           >
         </span>
@@ -68,19 +68,12 @@
           <b-button
             v-if="rule.satisfied_by && rule.satisfied_by.length > 0"
             v-b-modal.unmark-rule-as-duplicate-modal
-            variant="info"
+            variant="warning"
             >Unmark as Duplicate</b-button
           >
         </span>
         <!-- Disable and enable save & delete buttons based on locked state of rule -->
         <template v-if="rule.locked || rule.review_requestor_id ? true : false">
-          <span
-            v-b-tooltip.hover
-            class="d-inline-block"
-            title="Cannot save a control that is locked or under review."
-          >
-            <b-button variant="success" disabled>Save Control</b-button>
-          </span>
           <span
             v-if="effectivePermissions == 'admin'"
             v-b-tooltip.hover
@@ -89,8 +82,24 @@
           >
             <b-button variant="danger" disabled>Delete Control</b-button>
           </span>
+          <span
+            v-b-tooltip.hover
+            class="d-inline-block"
+            title="Cannot save a control that is locked or under review."
+          >
+            <b-button variant="success" disabled>Save Control</b-button>
+          </span>
         </template>
         <template v-else>
+          <!-- Delete rule -->
+          <b-button
+            v-if="effectivePermissions == 'admin'"
+            v-b-modal.delete-rule-modal
+            variant="danger"
+          >
+            Delete Control
+          </b-button>
+
           <!-- Save rule -->
           <CommentModal
             title="Save Control"
@@ -102,80 +111,156 @@
             wrapper-class="d-inline-block"
             @comment="saveRule($event)"
           />
+        </template>
 
-          <!-- Delete rule -->
-          <b-button
-            v-if="effectivePermissions == 'admin'"
-            v-b-modal.delete-rule-modal
-            variant="danger"
-          >
-            Delete Control
-          </b-button>
-          <b-modal
-            id="delete-rule-modal"
-            title="Delete Control"
-            centered
-            @ok="$root.$emit('delete:rule', rule.id)"
-          >
-            <p class="my-4">
-              Are you sure you want to delete this control?<br />This cannot be undone.
-            </p>
+        <!-- Comment -->
+        <CommentModal
+          title="Comment"
+          message="Submit general feedback on the control"
+          :require-non-empty="true"
+          button-text="Comment"
+          button-variant="secondary"
+          :button-disabled="false"
+          wrapper-class="d-inline-block"
+          @comment="commentFormSubmitted($event)"
+        />
 
-            <template #modal-footer="{ cancel, ok }">
-              <!-- Emulate built in modal footer ok and cancel button actions -->
-              <b-button @click="cancel()"> Cancel </b-button>
-              <b-button variant="danger" @click="ok()"> Permanently Delete Control </b-button>
-            </template>
-          </b-modal>
-          <b-modal
-            id="mark-rule-as-duplicate-modal"
-            title="Mark as Duplicate"
-            centered
-            @ok="$root.$emit('markDuplicate:rule', rule.id, satisfied_by_rule_id)"
-          >
-            <p>Mark control as duplicate of:</p>
-            <b-form-select
-              v-model="satisfied_by_rule_id"
-              :options="
-                rules
-                  .filter((r) => {
-                    return r.id !== rule.id && (!r.satisfied_by || r.satisfied_by.length === 0);
-                  })
-                  .map((r) => {
+        <!-- Review Status -->
+        <b-button
+          class="dropdown-toggle"
+          variant="primary"
+          @click="showReviewPane = !showReviewPane"
+        >
+          Review Status
+        </b-button>
+
+        <!-- Review card -->
+        <b-form class="reviewDropdownForm" @submit="reviewFormSubmitted">
+          <div class="reviewDropdownCard">
+            <b-card v-if="showReviewPane" class="shadow">
+              <!-- Submit button -->
+              <template #header>
+                <strong>Complete a Review</strong>
+                <i
+                  class="mdi mdi-close h5 mb-0 clickable float-right"
+                  aria-hidden="true"
+                  @click="showReviewPane = false"
+                />
+              </template>
+
+              <!-- Review comment -->
+              <b-form-group>
+                <b-form-textarea
+                  v-model="reviewComment"
+                  name="rule_review[comment]"
+                  placeholder="Leave a comment..."
+                  rows="3"
+                  required
+                />
+              </b-form-group>
+
+              <!-- Review action -->
+              <b-form-group label="" class="mb-0">
+                <b-form-radio
+                  v-for="action in reviewActions"
+                  :key="action.value"
+                  v-model="selectedReviewAction"
+                  v-b-tooltip.leftbottom.hover
+                  name="review-action-radios"
+                  :value="action.value"
+                  class="mb-1"
+                  :disabled="!!action.disabledTooltip"
+                  :title="action.disabledTooltip"
+                >
+                  <p class="mb-0">
+                    <small
+                      ><strong>{{ action.name }}</strong></small
+                    >
+                  </p>
+                  <small
+                    ><em>{{ action.description }}</em></small
+                  >
+                </b-form-radio>
+              </b-form-group>
+
+              <!-- Submit button -->
+              <template #footer>
+                <b-button
+                  type="submit"
+                  size="sm"
+                  variant="primary"
+                  :disabled="selectedReviewAction == ''"
+                  >Submit Review</b-button
+                >
+              </template>
+            </b-card>
+          </div>
+        </b-form>
+
+        <b-modal
+          id="delete-rule-modal"
+          title="Delete Control"
+          centered
+          @ok="$root.$emit('delete:rule', rule.id)"
+        >
+          <p class="my-2">
+            Are you sure you want to delete this control?<br />This cannot be undone.
+          </p>
+
+          <template #modal-footer="{ cancel, ok }">
+            <!-- Emulate built in modal footer ok and cancel button actions -->
+            <b-button @click="cancel()"> Cancel </b-button>
+            <b-button variant="danger" @click="ok()"> Permanently Delete Control </b-button>
+          </template>
+        </b-modal>
+        <b-modal
+          id="mark-rule-as-duplicate-modal"
+          title="Mark as Duplicate"
+          centered
+          @ok="$root.$emit('markDuplicate:rule', rule.id, satisfied_by_rule_id)"
+        >
+          <p>Mark control as duplicate of:</p>
+          <b-form-select
+            v-model="satisfied_by_rule_id"
+            :options="
+              rules
+                .filter((r) => {
+                  return r.id !== rule.id && (!r.satisfied_by || r.satisfied_by.length === 0);
+                })
+                .map((r) => {
+                  return { value: r.id, text: formatRuleId(r.rule_id) };
+                })
+            "
+          />
+          <template #modal-footer="{ cancel, ok }">
+            <!-- Emulate built in modal footer ok and cancel button actions -->
+            <b-button @click="cancel()"> Cancel </b-button>
+            <b-button variant="info" @click="ok()"> OK </b-button>
+          </template>
+        </b-modal>
+        <b-modal
+          id="unmark-rule-as-duplicate-modal"
+          title="Unmark as Duplicate"
+          centered
+          @ok="$root.$emit('unmarkDuplicate:rule', rule.id, satisfied_by_rule_id)"
+        >
+          <p>Unmark control as duplicate of:</p>
+          <b-form-select
+            v-model="satisfied_by_rule_id"
+            :options="
+              rule.satisfied_by
+                ? rule.satisfied_by.map((r) => {
                     return { value: r.id, text: formatRuleId(r.rule_id) };
                   })
-              "
-            />
-            <template #modal-footer="{ cancel, ok }">
-              <!-- Emulate built in modal footer ok and cancel button actions -->
-              <b-button @click="cancel()"> Cancel </b-button>
-              <b-button variant="info" @click="ok()"> OK </b-button>
-            </template>
-          </b-modal>
-          <b-modal
-            id="unmark-rule-as-duplicate-modal"
-            title="Unmark as Duplicate"
-            centered
-            @ok="$root.$emit('unmarkDuplicate:rule', rule.id, satisfied_by_rule_id)"
-          >
-            <p>Unmark control as duplicate of:</p>
-            <b-form-select
-              v-model="satisfied_by_rule_id"
-              :options="
-                rule.satisfied_by
-                  ? rule.satisfied_by.map((r) => {
-                      return { value: r.id, text: formatRuleId(r.rule_id) };
-                    })
-                  : []
-              "
-            />
-            <template #modal-footer="{ cancel, ok }">
-              <!-- Emulate built in modal footer ok and cancel button actions -->
-              <b-button @click="cancel()"> Cancel </b-button>
-              <b-button variant="info" @click="ok()"> OK </b-button>
-            </template>
-          </b-modal>
-        </template>
+                : []
+            "
+          />
+          <template #modal-footer="{ cancel, ok }">
+            <!-- Emulate built in modal footer ok and cancel button actions -->
+            <b-button @click="cancel()"> Cancel </b-button>
+            <b-button variant="info" @click="ok()"> OK </b-button>
+          </template>
+        </b-modal>
       </div>
     </div>
   </div>
@@ -218,6 +303,9 @@ export default {
   data: function () {
     return {
       satisfied_by_rule_id: null,
+      selectedReviewAction: null,
+      showReviewPane: false,
+      reviewComment: "",
     };
   },
   computed: {
@@ -227,6 +315,102 @@ export default {
         return histories[0].name || "Unknown User";
       }
       return "Unknown User";
+    },
+    reviewActions: function () {
+      // Set some helper variables for readability
+      const isAdmin = !this.readOnly && this.effectivePermissions == "admin";
+      const isReviewer = !this.readOnly && this.effectivePermissions == "reviewer";
+      const isRequestor = !this.readOnly && this.currentUserId == this.rule.review_requestor_id;
+      const isUnderReview = this.rule.review_requestor_id != null;
+
+      return [
+        // should only be able to request review if
+        // - not currently under review
+        // - not currently locked
+        {
+          value: "request_review",
+          name: "Request Review",
+          description: "control will not be editable during the review process",
+          disabledTooltip: isUnderReview
+            ? "Control is already under review"
+            : this.rule.locked
+            ? "Control is currently locked"
+            : null,
+        },
+
+        // should only be able to revoke review request if
+        // - current user is admin
+        // - OR current user originally requested the review
+        {
+          value: "revoke_review_request",
+          name: "Revoke Review Request",
+          description: "revoke your request for review - control will be editable again",
+          disabledTooltip: !(isAdmin || isRequestor)
+            ? "Only an admin or the review requestor can revoke the current review request"
+            : !isUnderReview
+            ? "Control is not currently under review"
+            : null,
+        },
+
+        // should only be able to request changes if
+        // - current user is a reviewer or admin
+        // - control is currently under review
+        {
+          value: "request_changes",
+          name: "Request Changes",
+          description: "request changes on the control - control will be editable again",
+          disabledTooltip: !(isAdmin || isReviewer)
+            ? "Only an admin or reviewer can request changes"
+            : !isUnderReview
+            ? "Control is not currently under review"
+            : null,
+        },
+
+        // should only be able to approve if
+        // - current user is a reviewer or admin
+        // - control is currently under review
+        {
+          value: "approve",
+          name: "Approve",
+          description: "approve the control - control will become locked",
+          disabledTooltip: !(isAdmin || isReviewer)
+            ? "Only an admin or reviewer can approve"
+            : !isUnderReview
+            ? "Control is not currently under review"
+            : null,
+        },
+
+        // should only be able to lock control if
+        // - current user is admin
+        // - control is not under review
+        // - control is not locked
+        {
+          value: "lock_control",
+          name: "Lock Control",
+          description: "skip the review process - control will be immediately locked",
+          disabledTooltip: !isAdmin
+            ? "Only an admin can directly lock a control"
+            : isUnderReview
+            ? "Cannot lock a control that is currently under review"
+            : this.rule.locked
+            ? "Cannot lock a control that is already locked"
+            : null,
+        },
+
+        // should only be able to unlock a control if
+        // - current user is admin
+        // - control is locked
+        {
+          value: "unlock_control",
+          name: "Unlock Control",
+          description: "unlock the control - control will be editable again",
+          disabledTooltip: !isAdmin
+            ? "Only an admin can unlock a control"
+            : !this.rule.locked
+            ? "Cannot unlock a control that is not locked"
+            : null,
+        },
+      ];
     },
   },
   methods: {
@@ -249,8 +433,66 @@ export default {
     formatRuleId: function (id) {
       return `${this.projectPrefix}-${id}`;
     },
+    commentFormSubmitted: function (comment) {
+      // guard against invalid comment body
+      if (!comment.trim()) {
+        return;
+      }
+
+      axios
+        .post(`/rules/${this.rule.id}/reviews`, {
+          review: {
+            action: "comment",
+            comment: comment,
+          },
+        })
+        .then(this.reviewSubmitSuccess)
+        .catch(this.alertOrNotifyResponse);
+    },
+    reviewFormSubmitted: function (event) {
+      event.preventDefault();
+
+      // guard against invalid comment body
+      if (!this.reviewComment.trim() || !this.selectedReviewAction) {
+        return;
+      }
+
+      axios
+        .post(`/rules/${this.rule.id}/reviews`, {
+          review: {
+            action: this.selectedReviewAction,
+            comment: this.reviewComment.trim(),
+          },
+        })
+        .then(this.reviewSubmitSuccess)
+        .catch(this.alertOrNotifyResponse);
+    },
+    reviewSubmitSuccess: function (response) {
+      this.alertOrNotifyResponse(response);
+      this.reviewComment = "";
+      this.selectedReviewAction = null;
+      this.showReviewPane = false;
+      this.$root.$emit("refresh:rule", this.rule.id, "all");
+    },
   },
 };
 </script>
 
-<style scoped></style>
+<style scoped>
+.reviewDropdownCard {
+  position: absolute;
+  top: 0;
+  right: 0;
+  height: 0;
+  width: 33vw;
+  z-index: 1;
+}
+
+.reviewDropdownForm {
+  position: absolute;
+  height: 100%;
+  right: 10rem;
+  width: 0;
+  margin-top: 0.25rem;
+}
+</style>

--- a/app/javascript/components/rules/RuleHistories.vue
+++ b/app/javascript/components/rules/RuleHistories.vue
@@ -53,7 +53,7 @@ export default {
   },
   data: function () {
     return {
-      showHistories: false,
+      showHistories: true,
     };
   },
 };

--- a/app/javascript/components/rules/RuleReviews.vue
+++ b/app/javascript/components/rules/RuleReviews.vue
@@ -10,74 +10,6 @@
     </div>
 
     <b-collapse id="collapse-reviews" v-model="showReviews">
-      <!-- New review action -->
-      <b-button
-        v-if="!readOnly"
-        class="dropdown-toggle m-2"
-        variant="primary"
-        size="sm"
-        @click="showReviewPane = !showReviewPane"
-      >
-        Add Review or Comment
-      </b-button>
-
-      <!-- Review card -->
-      <b-form class="reviewDropdownForm" @submit="reviewFormSubmitted">
-        <div class="reviewDropdownCard">
-          <b-card v-if="showReviewPane" class="shadow">
-            <!-- Submit button -->
-            <template #header>
-              <strong>Complete a Review</strong>
-              <i
-                class="mdi mdi-close h5 mb-0 clickable float-right"
-                aria-hidden="true"
-                @click="showReviewPane = false"
-              />
-            </template>
-
-            <!-- Review comment -->
-            <b-form-group>
-              <b-form-textarea
-                v-model="reviewComment"
-                name="rule_review[comment]"
-                placeholder="Leave a comment..."
-                rows="3"
-                required
-              />
-            </b-form-group>
-
-            <!-- Review action -->
-            <b-form-group label="" class="mb-0">
-              <b-form-radio
-                v-for="action in reviewActions"
-                :key="action.value"
-                v-model="selectedReviewAction"
-                v-b-tooltip.leftbottom.hover
-                name="review-action-radios"
-                :value="action.value"
-                class="mb-1"
-                :disabled="action.disabledTooltip != ''"
-                :title="action.disabledTooltip"
-              >
-                <p class="mb-0">
-                  <small
-                    ><strong>{{ action.name }}</strong></small
-                  >
-                </p>
-                <small
-                  ><em>{{ action.description }}</em></small
-                >
-              </b-form-radio>
-            </b-form-group>
-
-            <!-- Submit button -->
-            <template #footer>
-              <b-button type="submit" size="sm" variant="primary">Submit Review</b-button>
-            </template>
-          </b-card>
-        </div>
-      </b-form>
-
       <!-- All reviews -->
       <p
         v-if="numShownReviews < rule.reviews.length"
@@ -121,18 +53,11 @@ export default {
       type: Object,
       required: true,
     },
-    readOnly: {
-      type: Boolean,
-      required: false,
-    },
   },
   data: function () {
     return {
       numShownReviews: 5,
-      showReviews: false,
-      showReviewPane: false,
-      reviewComment: "",
-      selectedReviewAction: "comment",
+      showReviews: true,
       actionDescriptions: {
         comment: "Commented",
         request_review: "Requested Review",
@@ -148,160 +73,8 @@ export default {
     shownReviews: function () {
       return this.rule.reviews.slice(-1 * this.numShownReviews);
     },
-    reviewActions: function () {
-      let actions = [
-        {
-          value: "comment",
-          name: "Comment",
-          description: "submit general feedback on the control",
-          disabledTooltip: "",
-        },
-        {
-          value: "request_review",
-          name: "Request Review",
-          description: "control will not be editable during the review process",
-          disabledTooltip: "",
-        },
-        {
-          value: "revoke_review_request",
-          name: "Revoke Review Request",
-          description: "revoke your request for review - control will be editable again",
-          disabledTooltip: "",
-        },
-        {
-          value: "request_changes",
-          name: "Request Changes",
-          description: "request changes on the control - control will be editable again",
-          disabledTooltip: "",
-        },
-        {
-          value: "approve",
-          name: "Approve",
-          description: "approve the control - control will become locked",
-          disabledTooltip: "",
-        },
-        {
-          value: "lock_control",
-          name: "Lock Control",
-          description: "skip the review process - control will be immediately locked",
-          disabledTooltip: "",
-        },
-        {
-          value: "unlock_control",
-          name: "Unlock Control",
-          description: "unlock the control - control will be editable again",
-          disabledTooltip: "",
-        },
-      ];
-
-      // Set some helper variables for readability
-      const isAdmin = !this.readOnly && this.effectivePermissions == "admin";
-      const isReviewer = !this.readOnly && this.effectivePermissions == "reviewer";
-      const isRequestor = !this.readOnly && this.currentUserId == this.rule.review_requestor_id;
-      const isUnderReview = this.rule.review_requestor_id != null;
-
-      // should only be able to request review if
-      // - not currently under review
-      // - not currently locked
-      if (isUnderReview) {
-        actions[1]["disabledTooltip"] = "Control is already under review";
-      }
-      if (this.rule.locked) {
-        actions[1]["disabledTooltip"] = "Control is currently locked";
-      }
-
-      // should only be able to revoke review request if
-      // - current user is admin
-      // - OR current user originally requested the review
-      if (!(isAdmin || isRequestor)) {
-        actions[2]["disabledTooltip"] =
-          "Only an admin or the review requestor can revoke the current review request";
-      } else if (!isUnderReview) {
-        actions[2]["disabledTooltip"] = "Control is not currently under review";
-      }
-
-      // should only be able to request changes or approve if
-      // - current user is a reviewer or admin
-      // - control is currently under review
-      if (!(isAdmin || isReviewer)) {
-        actions[3]["disabledTooltip"] = "Only an admin or reviewer can request changes";
-        actions[4]["disabledTooltip"] = "Only an admin or reviewer can approve";
-      } else if (!isUnderReview) {
-        actions[3]["disabledTooltip"] = "Control is not currently under review";
-        actions[4]["disabledTooltip"] = "Control is not currently under review";
-      }
-
-      // should only be able to lock control if
-      // - current user is admin
-      // - control is not under review
-      // - control is not locked
-      if (!isAdmin) {
-        actions[5]["disabledTooltip"] = "Only an admin can directly lock a control";
-      } else {
-        if (isUnderReview) {
-          actions[5]["disabledTooltip"] = "Cannot lock a control that is currently under review";
-        } else if (this.rule.locked) {
-          actions[5]["disabledTooltip"] = "Cannot lock a control that is already locked";
-        }
-      }
-
-      // should only be able to unlock a control if
-      // - current user is admin
-      // - control is locked
-      if (!isAdmin) {
-        actions[6]["disabledTooltip"] = "Only an admin can unlock a control";
-      } else {
-        if (!this.rule.locked) {
-          actions[6]["disabledTooltip"] = "Cannot unlock a control that is not locked";
-        }
-      }
-
-      return actions;
-    },
-  },
-  methods: {
-    reviewFormSubmitted: function (event) {
-      event.preventDefault();
-
-      // guard against invalid comment body
-      if (!this.reviewComment.trim() || !this.selectedReviewAction) {
-        return;
-      }
-
-      axios
-        .post(`/rules/${this.rule.id}/reviews`, {
-          review: {
-            action: this.selectedReviewAction,
-            comment: this.reviewComment.trim(),
-          },
-        })
-        .then(this.reviewSubmitSuccess)
-        .catch(this.alertOrNotifyResponse);
-    },
-    reviewSubmitSuccess: function (response) {
-      this.alertOrNotifyResponse(response);
-      this.reviewComment = "";
-      this.selectedReviewAction = "comment";
-      this.showReviewPane = false;
-      this.$root.$emit("refresh:rule", this.rule.id, "all");
-    },
   },
 };
 </script>
 
-<style scoped>
-.reviewDropdownCard {
-  position: absolute;
-  top: 0;
-  right: 0;
-  height: 0;
-  width: 33vw;
-}
-
-.reviewDropdownForm {
-  position: absolute;
-  height: 100%;
-  right: 1rem;
-  width: 0;
-}
-</style>
+<style scoped></style>

--- a/app/javascript/components/rules/RuleSatisfactions.vue
+++ b/app/javascript/components/rules/RuleSatisfactions.vue
@@ -137,8 +137,8 @@ export default {
   },
   data: function () {
     return {
-      showAlsoSatisfies: false,
-      showSatisfiedBy: false,
+      showAlsoSatisfies: true,
+      showSatisfiedBy: true,
       satisfies_rule: null,
       satisfied_by_rule: null,
     };


### PR DESCRIPTION
https://github.com/mitre/vulcan/issues/452

We'd like to update the workflow for using the Request Review feature to make it more intuitive to the user.

We would like it so that when the authors complete writing a control, they immediately set the control to "Review Requested" from a reviewer. The reviewer can immediately accept a control as complete, which locks it from further editing, or they can ask for more changes. A reviewer can also look at a control and immediately approve it without review if they like.

Management (i.e. reviewers) should be able to tell quickly how much of a STIG is "done" by looking at the count of controls that have been flagged as "Review Requested."

Right now we can take all of these actions but the button that controls reviews is hidden in a collapsed pane on the right side of the screen. We just need to make this workflow more obvious.

- [ ] Combine Approve and Lock Control actions -- they're the same thing in this workflow
- [ ] Add a "Request Unlock" button accessible to authors for an Approved control to allow for mistakes
- [x] Move the "Add Review or Comment" button to the same button group as Clone/Mark Dup/Save/Delete etc.
- [x] Split "Add Review or Comment" into two buttons -- one should just be "Comment" with no little radio buttons underneath when clicked, just the coment box, and the other should be "Review Status" that handles all the rest of the actions it currently does
- [x] Make the Reviews & Comments and Revision History collapsibles open by default
- [ ] Make the entire right-hand pane that contains Reviews & Comments and Revision History collapsible to the side