### PR TITLE
501 copy component fails when selecting a newer srg version and a control has been previously deleted in the source component

### DIFF
--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -242,7 +242,7 @@ class Component < ApplicationRecord
     new_component.based_on = new_srg
     new_rules = new_srg.srg_rules.index_by(&:version)
     # update rules that haven't been configured
-    new_component.rules.select { |r| r.status != 'Applicable - Configurable' }.each do |old_rule|
+    new_component.rules.reject { |r| r.status == 'Applicable - Configurable' }.each do |old_rule|
       new_rule = new_rules[old_rule[:version]]
       # delete rules that are no longer present
       old_rule.destroy! && next if new_rule.blank? # calling destroy here will also persist new_component in the DB
@@ -263,7 +263,7 @@ class Component < ApplicationRecord
       error_messages = new_component.errors.full_messages
       # unpersist the saved new_component & reclone if unable to import all new rules
       new_component = new_component.destroy.amoeba_dup
-      error_messages.each { |e| new_component.errors.add(:base, e)  }
+      error_messages.each { |e| new_component.errors.add(:base, e) }
     end
 
     new_component
@@ -333,9 +333,9 @@ class Component < ApplicationRecord
     srg_rule_versions = filtered_srg_rules.pluck(:rule_id, :version).to_h
 
     filtered_benchmark_rules = if new_rule_versions.nil?
-                                benchmark.rule
+                                 benchmark.rule
                                else
-                                benchmark.rule.filter { |r| new_rule_versions.include?(r.version.first.version) }
+                                 benchmark.rule.filter { |r| new_rule_versions.include?(r.version.first.version) }
                                end
     rule_models = filtered_benchmark_rules.sort_by { |r| srg_rule_versions[r.id] }.each_with_index.map do |rule, idx|
       Rule.from_mapping(rule, id, starting_idx + idx + 1, srg_rules)


### PR DESCRIPTION
Fixed bug #501
Refactored the logic of `Component#duplicate` and `Component#from_mapping` to correctly copy a component and update the rules based a given new srg:
* Fixed the incorrect use of ActiveRecord methods `where` & `pluck`:
  * `where` & `pluck` applies on the database level. So if the model instance the      method is being called on is not persisted, the return value is an empty list. Switched to use enumerator methods `select` and `map` instead to get the expected behavior.
* Updated the based_on attribute of the new (copied) component to be the new given srg
* Fixed `#from_mapping` method to correctly check if a new list of rule versions was provided for import or if a null value was given
* Fixed how new `Rule#rule_id` are generated when importing new rules to always generate unique `rule_id` for a rule in a given component: `rule_id` was generated based on the (total count of rules + 1)  of the component. This created an error due the uniqueness constraint of `rule_id` in a given component in the scenario when some rules have been deleted from the component. Fixed it to generate new `rule_id` based on the `largest_rule_id` in the given component.
  e.g. scenario:
    1. Take component with rules ['000001', '000002', '000003']
    2. Delete the rule with `rule_id` '000001' from the component
    3. Now the component  has rules ['000002', '000003'] `total count = 2`
    4. Adding a new rule to the component:
      * Generating new `rule_id` based on `total count + 1` will generate '000003' which already exist => causing db error
      * Generating new `rule_id` based on `largest_rule_id + 1` will generate '000004'