### PR TITLE
Properly using #dup method for expected behavior:

### DIFF
--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -249,9 +249,9 @@ class Component < ApplicationRecord
 
       fields = %i[rule_severity rule_weight title ident ident_system fixtext fixtext_fixref fix_id]
       fields.each { |field| old_rule[field] = new_rule[field] }
-      old_rule.disa_rule_descriptions = new_rule.disa_rule_descriptions.dup
-      old_rule.rule_descriptions = new_rule.rule_descriptions.dup
-      old_rule.checks = new_rule.checks.dup
+      old_rule.disa_rule_descriptions = new_rule.disa_rule_descriptions.map(&:dup)
+      old_rule.rule_descriptions = new_rule.rule_descriptions.map(&:dup)
+      old_rule.checks = new_rule.checks.map(&:dup)
       old_rule.srg_rule = new_rule
     end
 


### PR DESCRIPTION
	* Before: dup method was applied to a list of ActiveRecord objects, which was making a shallow copy of the array without creating new records for the objects within the array. So e.g: assigning a list of checks [belonging to rule B] to rule A disassociate the checks from rule B, updating the foreign key to rule A id.
	* Fix: updated the logic to get the list of duplicated [new records] activeRecord model objects `map(&:dup)`.

Signed-off-by: Vanessa Fotso <vfotso@mitre.org>