### PR TITLE
530 populate gid and rid in inspec body data

### DIFF
--- a/app/helpers/export_helper.rb
+++ b/app/helpers/export_helper.rb
@@ -216,7 +216,7 @@ module ExportHelper # rubocop:todo Metrics/ModuleLength
       next if rule.satisfied_by.present?
 
       group = Ox::Element.new('Group')
-      group['id'] = "#{component[:prefix]}-#{rule[:rule_id]}"
+      group['id'] = "V-#{component[:prefix]}-#{rule[:rule_id]}"
 
       ox_el_helper(group, 'title', rule[:version])
       group_rule = Ox::Element.new('Rule')

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -215,8 +215,8 @@ class Rule < BaseRule
     control.add_tag(Inspec::Object::Tag.new('severity', rule_severity))
     control.add_tag(Inspec::Object::Tag.new('gtitle', version))
     control.add_tag(Inspec::Object::Tag.new('satisfies', satisfies.pluck(:version).sort)) if satisfies.present?
-    control.add_tag(Inspec::Object::Tag.new('gid', nil))
-    control.add_tag(Inspec::Object::Tag.new('rid', nil))
+    control.add_tag(Inspec::Object::Tag.new('gid', "V-#{component[:prefix]}-#{rule_id}"))
+    control.add_tag(Inspec::Object::Tag.new('rid', "SV-#{component[:prefix]}-#{rule_id}"))
     control.add_tag(Inspec::Object::Tag.new('stig_id', "#{component[:prefix]}-#{rule_id}"))
     control.add_tag(Inspec::Object::Tag.new('cci', ([ident] + satisfies.pluck(:ident)).uniq.sort)) if ident.present?
     control.add_tag(Inspec::Object::Tag.new('nist', ([nist_control_family] +


### PR DESCRIPTION
Also updated xccdf export to set the Vul ID value to start with a V- to match InSpec and official Vul ID syntax.

Rule ID and Vul ID should match between InSpec and XCCDF exports so STIG viewer checklist functionality works.