### PR TITLE
Disallow new project creation if not admin by default

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -31,6 +31,13 @@ class ApplicationController < ActionController::Base
     raise(NotAuthorizedError, 'You are not authorized to perform administrator actions.')
   end
 
+  def authorize_admin_or_create_permission_enabled
+    return if current_user&.admin? || Settings.project.create_permission_enabled
+
+    flash.alert = 'You are not authorized to create new projects.'
+    redirect_to root_path
+  end
+
   #  Project permssions checking
   def authorize_admin_project
     return if current_user&.can_admin_project?(@project)

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -11,7 +11,8 @@ class ProjectsController < ApplicationController
   before_action :set_project_permissions, only: %i[show]
   before_action :authorize_admin_project, only: %i[update destroy]
   before_action :authorize_viewer_project, only: %i[show]
-  before_action :authorize_logged_in, only: %i[index new create search]
+  before_action :authorize_logged_in, only: %i[index new search]
+  before_action :authorize_admin_or_create_permission_enabled, only: %i[create]
 
   def index
     @projects = current_user.available_projects.eager_load(:memberships).alphabetical.as_json(methods: %i[memberships])

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,11 +8,16 @@ module ApplicationHelper
 
   # Build the links shown to users in the navigation bar
   def base_navigation
-    [
+    nav_links = [
       { icon: 'mdi-folder-open-outline', name: 'Projects', link: projects_path },
-      { icon: 'mdi-timer-sand', name: 'Start New Project', link: new_project_path },
       { icon: 'mdi-stamper', name: 'Released Components', link: components_path },
       { icon: 'mdi-folder', name: 'SRGs', link: srgs_path }
     ]
+
+    if current_user&.admin? || Settings.project.create_permission_enabled
+      nav_links.insert(1, { icon: 'mdi-timer-sand', name: 'Start New Project', link: new_project_path })
+    end
+
+    nav_links
   end
 end

--- a/config/initializers/0_settings.rb
+++ b/config/initializers/0_settings.rb
@@ -14,6 +14,9 @@ Settings.local_login['enabled'] = false if Settings.local_login['enabled'].nil?
 Settings['user_registration'] ||= Settingslogic.new({})
 Settings.user_registration['enabled'] = false if Settings.user_registration['enabled'].nil?
 
+Settings['project'] ||= Settingslogic.new({})
+Settings.project['create_permission_enabled'] = false if Settings.project['create_permission_enabled'].nil?
+
 Settings['smtp'] ||= Settingslogic.new({})
 Settings.smtp['enabled'] = false if Settings.smtp['enabled'].nil?
 

--- a/config/vulcan.default.yml
+++ b/config/vulcan.default.yml
@@ -28,6 +28,8 @@ defaults: &defaults
     session_timeout: <%= ENV['VULCAN_SESSION_TIMEOUT'] || 60 %>
   user_registration:
     enabled: <%= ENV['VULCAN_ENABLE_USER_REGISTRATION'] || true %>
+  project:
+    create_permission_enabled: <%= ENV['VULCAN_PROJECT_CREATE_PERMISSION_ENABLED'] || false %>
   ldap:
     enabled: <%= ENV['VULCAN_ENABLE_LDAP'] || false %>
     servers:

--- a/config/vulcan.default.yml
+++ b/config/vulcan.default.yml
@@ -29,7 +29,7 @@ defaults: &defaults
   user_registration:
     enabled: <%= ENV['VULCAN_ENABLE_USER_REGISTRATION'] || true %>
   project:
-    create_permission_enabled: <%= ENV['VULCAN_PROJECT_CREATE_PERMISSION_ENABLED'] || false %>
+    create_permission_enabled: <%= ENV['VULCAN_PROJECT_CREATE_PERMISSION_ENABLED'] || true %>
   ldap:
     enabled: <%= ENV['VULCAN_ENABLE_LDAP'] || false %>
     servers:

--- a/docs/config.md
+++ b/docs/config.md
@@ -9,6 +9,8 @@ Vulcan can be set up in a few different ways. It can be done by having a vulcan.
 - [Configure Welcome Text and Contact Email](#configure-welcome-text-and-contact-email)
 - [Configure SMTP:](#configure-smtp) Sets up the smtp mailing server
 - [Configure Local Login:](#configure-local-login) Enables user to log in as well as turn email confirmation on and off
+- [Configure User Registration:](#configure-user-registration) Enables user sign-ups
+- [Configure Project Create Permissions:](#configure-project-create-permissions) Logged-In users can create projects
 - [Configure LDAP:](#configure-ldap)
 - [Configure Providers:](#configure-providers)
 
@@ -39,6 +41,9 @@ Vulcan can be set up in a few different ways. It can be done by having a vulcan.
 
 ## Configure User Registration
 - **enabled:** Allows users to register themselves on the Vulcan app. `(ENV: VULCAN_ENABLE_USER_REGISTRATION)(default: true)`
+
+## Configure Project Create Permissions
+- **create_permission_enabled:** Allows logged-in users to create new projects on the Vulcan app. `(ENV: VULCAN_PROJECT_CREATE_PERMISSION_ENABLED)(default: false)`
 
 ## Configure LDAP
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -43,7 +43,7 @@ Vulcan can be set up in a few different ways. It can be done by having a vulcan.
 - **enabled:** Allows users to register themselves on the Vulcan app. `(ENV: VULCAN_ENABLE_USER_REGISTRATION)(default: true)`
 
 ## Configure Project Create Permissions
-- **create_permission_enabled:** Allows logged-in users to create new projects on the Vulcan app. `(ENV: VULCAN_PROJECT_CREATE_PERMISSION_ENABLED)(default: false)`
+- **create_permission_enabled:** Allows any logged-in users to create new projects in Vulcan if enabled, otherwise only Vulcan Admins are allowed to create projects. `(ENV: VULCAN_PROJECT_CREATE_PERMISSION_ENABLED)(default: true)`
 
 ## Configure LDAP
 


### PR DESCRIPTION
- Updated `before_action` on the project controllers to disallow non-admin users to create new projects
- Created a function in the application controller
- Added config & introduced an environment variable if some type of deployments want to have users (non-admins) create new projects
- Docs updated