### PR TITLE
Bump omniauth-rails_csrf_protection Gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem 'gitlab_omniauth-ldap', '~> 2.2.0', require: 'omniauth-ldap'
 # Allow users to sign in with GitHub
 gem 'omniauth-github'
 # https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284
-gem 'omniauth-rails_csrf_protection', '~> 0.1'
+gem 'omniauth-rails_csrf_protection', '~> 1.0'
 # Allow users to sign in with OIDC providers
 gem 'omniauth_openid_connect', '~> 0.6.0'
 # Vulcan settings

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,7 +102,7 @@ GEM
       concurrent-ruby
     childprocess (4.1.0)
     coderay (1.1.3)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.2.2)
     crass (1.0.6)
     database_cleaner-active_record (2.0.1)
       activerecord (>= 5.a)
@@ -116,7 +116,7 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.5.0)
     docile (1.4.0)
-    erubi (1.10.0)
+    erubi (1.12.0)
     erubis (2.7.0)
     factory_bot (5.2.0)
       activesupport (>= 4.2.0)
@@ -213,7 +213,7 @@ GEM
     matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
-    mini_portile2 (2.8.0)
+    mini_portile2 (2.8.1)
     minitest (5.17.0)
     mitre-inspec-objects (0.3.3)
       inspec-core
@@ -235,12 +235,12 @@ GEM
       net-protocol
     net-ssh (6.1.0)
     nio4r (2.5.8)
-    nokogiri (1.13.10)
+    nokogiri (1.14.2)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
-    nokogiri (1.13.10-x86_64-darwin)
+    nokogiri (1.14.2-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.13.10-x86_64-linux)
+    nokogiri (1.14.2-x86_64-linux)
       racc (~> 1.4)
     nokogiri-happymapper (0.9.0)
       nokogiri (~> 1.5)
@@ -262,7 +262,7 @@ GEM
       omniauth (>= 1.9, < 3)
     omniauth-rails_csrf_protection (1.0.1)
       actionpack (>= 4.2)
-      omniauth (>= 1.3.1)
+      omniauth (~> 2.0)
     omniauth_openid_connect (0.6.1)
       omniauth (>= 1.9, < 3)
       openid_connect (~> 1.1)
@@ -293,7 +293,7 @@ GEM
     puma (4.3.12)
       nio4r (~> 2.0)
     pyu-ruby-sasl (0.0.3.3)
-    racc (1.6.1)
+    racc (1.6.2)
     rack (2.2.6.2)
     rack-oauth2 (1.21.3)
       activesupport
@@ -305,8 +305,8 @@ GEM
       rack
     rack-proxy (0.7.2)
       rack
-    rack-test (1.1.0)
-      rack (>= 1.0, < 3)
+    rack-test (2.0.2)
+      rack (>= 1.3)
     rails (6.1.4.6)
       actioncable (= 6.1.4.6)
       actionmailbox (= 6.1.4.6)
@@ -325,7 +325,7 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.4.4)
+    rails-html-sanitizer (1.5.0)
       loofah (~> 2.19, >= 2.19.1)
     railties (6.1.4.6)
       actionpack (= 6.1.4.6)
@@ -463,7 +463,7 @@ GEM
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
-    tzinfo (2.0.5)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     tzinfo-data (1.2021.5)
       tzinfo (>= 1.0.0)
@@ -500,7 +500,7 @@ GEM
     wisper (2.0.1)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.6)
+    zeitwerk (2.6.7)
 
 PLATFORMS
   ruby
@@ -560,4 +560,4 @@ RUBY VERSION
    ruby 2.7.5p203
 
 BUNDLED WITH
-   2.2.32
+   2.3.10

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -260,7 +260,7 @@ GEM
     omniauth-oauth2 (1.7.2)
       oauth2 (~> 1.4)
       omniauth (>= 1.9, < 3)
-    omniauth-rails_csrf_protection (0.1.2)
+    omniauth-rails_csrf_protection (1.0.1)
       actionpack (>= 4.2)
       omniauth (>= 1.3.1)
     omniauth_openid_connect (0.6.1)
@@ -532,7 +532,7 @@ DEPENDENCIES
   nokogiri-happymapper
   omniauth (~> 2.1)
   omniauth-github
-  omniauth-rails_csrf_protection (~> 0.1)
+  omniauth-rails_csrf_protection (~> 1.0)
   omniauth_openid_connect (~> 0.6.0)
   ox
   pg (>= 0.18, < 2.0)


### PR DESCRIPTION
Updated the Gemfile by bumpting the csrf gem as per the dependencies listed in here.
https://rubygems.org/gems/omniauth-rails_csrf_protection/versions/1.0.1