### PR TITLE
VULCAN- 565: Add latest release version tag to Navbar component

### DIFF
--- a/app/javascript/components/navbar/App.vue
+++ b/app/javascript/components/navbar/App.vue
@@ -3,7 +3,7 @@
     <b-navbar toggleable="lg" type="dark" variant="dark">
       <b-navbar-brand id="heading" href="/">
         <i class="mdi mdi-radar" aria-hidden="true" />
-        VULCAN
+        VULCAN <span class="latest-release">{{ latestRelease }}</span>
       </b-navbar-brand>
 
       <b-navbar-toggle target="nav-collapse" />
@@ -66,6 +66,31 @@ export default {
       required: false,
     },
   },
+  data() {
+    return {
+      latestRelease: "",
+    };
+  },
+  mounted() {
+    this.fetchLatestRelease();
+  },
+  methods: {
+    fetchLatestRelease() {
+      const owner = "mitre";
+      const repo = "vulcan";
+
+      // Make the API request to fetch the latest release
+      fetch(`https://api.github.com/repos/${owner}/${repo}/releases/latest`)
+        .then((response) => response.json())
+        .then((data) => {
+          this.latestRelease = data.tag_name;
+        })
+        .catch((error) => {
+          // console.error("Error fetching latest release:", error);
+          this.latestRelease = "";
+        });
+    },
+  },
 };
 </script>
 
@@ -74,6 +99,10 @@ export default {
   font-family: verdana, arial, helvetica, sans-serif;
   font-weight: 700;
   letter-spacing: 1px;
+}
+
+.latest-release {
+  font-size: 0.6em;
 }
 .right-container {
   gap: 32px;

--- a/app/javascript/components/navbar/App.vue
+++ b/app/javascript/components/navbar/App.vue
@@ -3,9 +3,8 @@
     <b-navbar toggleable="lg" type="dark" variant="dark">
       <b-navbar-brand id="heading" href="/">
         <i class="mdi mdi-radar" aria-hidden="true" />
-        VULCAN <span class="latest-release">{{ latestRelease }}</span>
+        VULCAN <span class="latest-release">{{ currentVersion }}</span>
       </b-navbar-brand>
-
       <b-navbar-toggle target="nav-collapse" />
 
       <b-collapse id="nav-collapse" is-nav>
@@ -34,12 +33,22 @@
         </div>
       </b-collapse>
     </b-navbar>
+    <b-alert
+      dismissible
+      fade
+      :show="updateAvailable"
+      class="text-center"
+      @dismissed="updateAvailable = false"
+    >
+      New version: Vulcan {{ latestRelease }} is now available!!
+    </b-alert>
   </div>
 </template>
 
 <script>
 import NavbarItem from "./NavbarItem.vue";
 import SrgIdSearch from "./SrgIdSearch.vue";
+import { version } from "../../../../package.json";
 
 export default {
   name: "Navbar",
@@ -69,6 +78,8 @@ export default {
   data() {
     return {
       latestRelease: "",
+      currentVersion: version,
+      updateAvailable: false,
     };
   },
   mounted() {
@@ -78,17 +89,19 @@ export default {
     fetchLatestRelease() {
       const owner = "mitre";
       const repo = "vulcan";
-
       // Make the API request to fetch the latest release
       fetch(`https://api.github.com/repos/${owner}/${repo}/releases/latest`)
         .then((response) => response.json())
         .then((data) => {
-          this.latestRelease = data.tag_name;
+          this.latestRelease = data.tag_name.substring(1);
+          this.updateAvailable = this.checkUpdateAvailable();
         })
         .catch((error) => {
-          // console.error("Error fetching latest release:", error);
           this.latestRelease = "";
         });
+    },
+    checkUpdateAvailable() {
+      return this.latestRelease.trim() !== "" && this.latestRelease !== this.currentVersion;
     },
   },
 };

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "vue-template-compiler": "^2.6.11",
     "vue-turbolinks": "^2.1.0"
   },
-  "version": "0.1.0",
+  "version": "2.1.1",
   "devDependencies": {
     "eslint": "^8.25.0",
     "eslint-config-prettier": "^8.3.0",


### PR DESCRIPTION
This pull request adds the latest release version tag to the Navbar component. The tag is fetched from the GitHub API and displayed next to the "VULCAN" text. It improves the user experience by showing the current release version prominently.

Changes Made:
- Updated the template to include the latest release tag
- Added  a method & mounted property to handle asynchronous API call
- Applied CSS styling to the latest release value for a smaller font size

Fixes #565 