### PR TITLE
VULCAN-559: Support for Multiple CCIs

### DIFF
--- a/app/constants/import_constants.rb
+++ b/app/constants/import_constants.rb
@@ -17,7 +17,8 @@ module ImportConstants
   OPTIONAL_MAPPING_CONSTANTS = {
     vendor_comments: 'Vendor Comments',
     mitigation: 'Mitigation',
-    inspec_control_body: 'InSpec Control Body'
+    inspec_control_body: 'InSpec Control Body',
+    ident: 'CCI'
   }.freeze
 
   IMPORT_MAPPING = REQUIRED_MAPPING_CONSTANTS.merge(OPTIONAL_MAPPING_CONSTANTS)

--- a/app/models/base_rule.rb
+++ b/app/models/base_rule.rb
@@ -76,7 +76,10 @@ class BaseRule < ApplicationRecord
   end
 
   def nist_control_family
-    CCI_TO_NIST_CONSTANT[ident&.to_sym]
+    ccis = ident.to_s.split(/, */)
+    ia_controls = []
+    ccis.each { |cci| ia_controls << CCI_TO_NIST_CONSTANT[cci.to_sym] }
+    ia_controls.uniq.join(', ')
   end
 
   private

--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -150,6 +150,8 @@ class Component < ApplicationRecord
       r.srg_rule_id = srg_rule.id
       # Get the inspec control body if provided
       r.inspec_control_body = row[IMPORT_MAPPING[:inspec_control_body]]
+      # It's possible to have multiple cci on the spreadsheet. Parse cci from the spreadsheet.
+      r.ident = row[IMPORT_MAPPING[:ident]]
 
       disa_rule_description = r.disa_rule_descriptions.first
       disa_rule_description.vuln_discussion = row[IMPORT_MAPPING[:vuln_discussion]]

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -218,9 +218,8 @@ class Rule < BaseRule
     control.add_tag(Inspec::Object::Tag.new('gid', "V-#{component[:prefix]}-#{rule_id}"))
     control.add_tag(Inspec::Object::Tag.new('rid', "SV-#{component[:prefix]}-#{rule_id}"))
     control.add_tag(Inspec::Object::Tag.new('stig_id', "#{component[:prefix]}-#{rule_id}"))
-    control.add_tag(Inspec::Object::Tag.new('cci', ([ident] + satisfies.pluck(:ident)).uniq.sort)) if ident.present?
-    control.add_tag(Inspec::Object::Tag.new('nist', ([nist_control_family] +
-                                                     satisfies.map(&:nist_control_family)).uniq.sort))
+    control.add_tag(Inspec::Object::Tag.new('cci', format_inspec_control_cci.uniq.sort)) if ident.present?
+    control.add_tag(Inspec::Object::Tag.new('nist', format_inspec_control_nist.uniq.sort))
     if desc.present?
       %i[false_negatives false_positives documentable mitigations severity_override_guidance potential_impacts
          third_party_tools mitigation_control responsibility ia_controls].each do |field|
@@ -250,6 +249,18 @@ class Rule < BaseRule
   end
 
   private
+
+  def format_inspec_control_cci
+    rule_cci = ident.split(/, */)
+    satisfies_cci = satisfies.pluck(:ident).map { |cci| cci.split(/, */) }.flatten
+    rule_cci + satisfies_cci
+  end
+
+  def format_inspec_control_nist
+    rule_nist = nist_control_family.split(/, */)
+    statisfies_nist = satisfies.map(&:nist_control_family).map { |nist| nist.split(/, */) }.flatten
+    rule_nist + statisfies_nist
+  end
 
   def single_rule_clone?
     @single_rule_clone

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -39,7 +39,7 @@ class Rule < BaseRule
 
   before_validation :set_rule_id
   before_save :apply_audit_comment
-  before_save :update_inspec_code
+  before_save :sort_ident, :update_inspec_code
   before_destroy :prevent_destroy_if_under_review_or_locked
   after_destroy :update_component_rules_count
   after_save :update_component_rules_count
@@ -249,6 +249,10 @@ class Rule < BaseRule
   end
 
   private
+
+  def sort_ident
+    self.ident = ident.to_s.split(/, */).uniq.sort.join(', ')
+  end
 
   def format_inspec_control_cci
     rule_cci = ident.split(/, */)

--- a/spec/models/rules_spec.rb
+++ b/spec/models/rules_spec.rb
@@ -260,4 +260,12 @@ RSpec.describe Review, type: :model do
       @p1r1.reload
     end
   end
+
+  context 'rule with multiple ident' do
+    it 'should have a unique string list of cci sorted in ascending order' do
+      @p1r1.ident = 'CCI-000068, CCI-000054, CCI-000054'
+      @p1r1.save!
+      expect(@p1r1.ident).to eq('CCI-000054, CCI-000068')
+    end
+  end
 end


### PR DESCRIPTION
- Reading ccis from the imported spreadsheet
- Refactored getting nist_control_family to accomodate for instances of multi ccis
- Refactored inspec code to accomodate for instances of multi ccis

![Screenshot 2023-05-03 at 12 09 31 PM](https://user-images.githubusercontent.com/46642178/235983964-d9971035-9d52-4534-a54f-cae370d9bce1.png)

![Screenshot 2023-05-03 at 12 10 04 PM](https://user-images.githubusercontent.com/46642178/235984005-fd83dc16-b8d1-43ee-b9d7-33600465bda1.png)

Am I missing a workflow that uses `rule.ident`?

Fix #559 