### PR TITLE
fix project update logic for detecting name changes correctly

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -74,9 +74,14 @@ class ProjectsController < ApplicationController
 
   # Update project and response with json
   def update
+    current_project_name = @project.name
     if @project.update(project_params)
-      render json: { toast: 'Project updated successfully' }
-      send_slack_notification(:rename_project, @project) if Settings.slack.enabled
+      if project_name_changed?(current_project_name, project_params)
+        render json: { toast: 'Project renamed successfully' }
+        send_slack_notification(:rename_project, @project) if Settings.slack.enabled
+      else
+        render json: { toast: 'Project updated successfully' }
+      end
     else
       render json: {
         toast: {
@@ -159,5 +164,9 @@ class ProjectsController < ApplicationController
       :name,
       project_metadata_attributes: { data: {} }
     )
+  end
+
+  def project_name_changed?(current_project_name, project_params)
+    project_params['name'].present? && project_params['name'] != current_project_name
   end
 end


### PR DESCRIPTION
As highlighted in the below screenshot, when project metadata is updated it is triggering a `rename_project` slack notification.

**Project Metadata Update:**
<img width="1704" alt="Vulcan_Project_Meta_Update" src="https://github.com/mitre/vulcan/assets/34048837/fd82be0e-4ba5-4330-b3be-86760f6df8cf">

**Slack Notification Triggered:**
<img width="451" alt="Vulcan_Project_Rename_Notif" src="https://github.com/mitre/vulcan/assets/34048837/deca8e7c-6f42-4ea6-8fe3-66070c2af51b">

Fix -
- Simplified the project update logic in the update action.
- Introduced the `project_name_changed?` method to check if the project name has changed.

After this `project_rename` slack notification is not triggered if metadata is updated. And the flash messages are also updated accordingly.