### PR TITLE
New Feature: Enable setting up Project visibility and Requesting access to a project

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -111,6 +111,7 @@ class ApplicationController < ActionController::Base
     mailer.request_review_changes(*args).deliver_now if action == 'request_changes'
     mailer.welcome_project_member(*args).deliver_now if action == 'project_user'
     mailer.welcome_component_member(*args).deliver_now if action == 'component_user'
+    mailer.project_access_denied(*args).deliver_now if action == 'reject_access'
   end
 
   private

--- a/app/controllers/memberships_controller.rb
+++ b/app/controllers/memberships_controller.rb
@@ -25,8 +25,12 @@ class MembershipsController < ApplicationController
       )
     end
 
-    membership = Membership.new(membership_create_params)
+    filtered_params = membership_create_params.except(:access_request_id)
+    membership = Membership.new(filtered_params)
     if membership.save
+      if membership_create_params[:access_request_id].present?
+        delete_access_request(membership_create_params[:access_request_id])
+      end
       flash.notice = 'Successfully created membership.'
       case membership.membership_type
       when 'Project'
@@ -93,7 +97,7 @@ class MembershipsController < ApplicationController
   end
 
   def membership_create_params
-    params.require(:membership).permit(:user_id, :role, :membership_id, :membership_type)
+    params.require(:membership).permit(:user_id, :role, :membership_id, :membership_type, :access_request_id)
   end
 
   def membership_update_params
@@ -104,5 +108,10 @@ class MembershipsController < ApplicationController
     return unless Settings.slack.enabled
 
     send_slack_notification(notification_type, membership)
+  end
+
+  def delete_access_request(access_request_id)
+    access_request = ProjectAccessRequest.find_by(id: access_request_id)
+    access_request&.destroy
   end
 end

--- a/app/controllers/project_access_requests_controller.rb
+++ b/app/controllers/project_access_requests_controller.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+##
+# Controller for managing request to access a specific project.
+#
+class ProjectAccessRequestsController < ApplicationController
+  def create
+    @project = Project.find(params[:project_id])
+    @access_request = ProjectAccessRequest.new(user: current_user, project: @project)
+
+    if @access_request.save
+      flash.notice = 'Your request for access has been sent.'
+    else
+      flash.alert = @access_request.errors.full_messages.to_sentence
+    end
+    redirect_to projects_path
+  end
+
+  def destroy
+    @access_request = ProjectAccessRequest.find(params[:id])
+    if @access_request.destroy
+      if params[:action] == 'reject' && Settings.smtp.enabled
+        send_smtp_notification(UserMailer, 'reject_access', @access_request.user)
+      end
+      flash.notice = 'Your request for access has been cancelled.'
+    else
+      flash.alert = @access_request.errors.full_messages.to_sentence
+    end
+
+    redirect_back(fallback_location: projects_path)
+  end
+end

--- a/app/javascript/components/memberships/NewMembership.vue
+++ b/app/javascript/components/memberships/NewMembership.vue
@@ -97,6 +97,12 @@
             :value="selectedUserId"
           />
           <input
+            id="access_request_id"
+            type="hidden"
+            name="membership[access_request_id]"
+            :value="access_request_id"
+          />
+          <input
             id="NewMembershipRole"
             type="hidden"
             name="membership[role]"
@@ -144,11 +150,19 @@ export default {
       type: Array,
       required: true,
     },
+    selected_member: {
+      type: Object,
+      required: false,
+    },
+    access_request_id: {
+      type: Number,
+      required: false,
+    },
   },
   data: function () {
     return {
       search: "",
-      selectedUser: null,
+      selectedUser: this.selected_member,
       selectedRole: null,
       roleDescriptions: [
         "Read only access to the Project or Component",

--- a/app/javascript/components/project/NewProject.vue
+++ b/app/javascript/components/project/NewProject.vue
@@ -10,12 +10,33 @@
       />
       <b-row>
         <b-col md="6">
+          <!-- Name -->
           <b-form-group label="Project Title">
             <b-form-input
               placeholder="Project Title"
               required
               name="project[name]"
               autocomplete="off"
+            />
+          </b-form-group>
+          <!-- Description -->
+          <b-form-group label="Project Description">
+            <b-form-textarea
+              placeholder="Project Description"
+              required
+              name="project[description]"
+              autocomplete="off"
+            />
+          </b-form-group>
+          <!-- Visibility -->
+          <b-form-group
+            label="Visibility"
+            description="Marking the project as discoverable means that non-members will see the project's details (name, description, etc.) on the projects' list and can request access."
+          >
+            <b-form-select
+              required
+              name="project[visibility]"
+              :options="['discoverable', 'hidden']"
             />
           </b-form-group>
           <b-button type="submit" variant="primary"> Create Project </b-button>

--- a/app/javascript/components/project/Project.vue
+++ b/app/javascript/components/project/Project.vue
@@ -150,6 +150,7 @@
               :memberships_count="project.memberships_count"
               :available_members="project.available_members"
               :available_roles="available_roles"
+              :access_requests="project.access_requests"
             />
           </b-tab>
         </b-tabs>

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -30,6 +30,20 @@ class UserMailer < ApplicationMailer
     end
   end
 
+  def project_access_denied(*args)
+    @user, @project = *args
+    # begin
+    #   mail(
+    #     to: @user.email,
+    #     cc: @project_admins,
+    #     subject: "Vulcan Component Access - #{@component.name}",
+    #     from: Settings.smtp.settings.user_name
+    #   )
+    # rescue StandardError => e
+    #   Rails.logger.error("Error delivering welcome email to user #{@user.name}: #{e.message}")
+    # end
+  end
+
   def request_review(*args)
     parse_mailer_review_args(*args)
     begin

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -4,12 +4,15 @@
 class Project < ApplicationRecord
   attr_accessor :current_user
 
+  enum visibility: { discoverable: 0, hidden: 1 }
+
   audited except: %i[id admin_name admin_email memberships_count created_at updated_at], max_audits: 1000
 
   has_many :memberships, -> { includes :user }, as: :membership, inverse_of: :membership, dependent: :destroy
   has_many :users, through: :memberships
   has_many :components, dependent: :destroy
   has_many :rules, through: :components
+  has_many :access_requests, class_name: 'ProjectAccessRequest', dependent: :destroy
   has_one :project_metadata, dependent: :destroy
   accepts_nested_attributes_for :project_metadata, :memberships
 

--- a/app/models/project_access_request.rb
+++ b/app/models/project_access_request.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class ProjectAccessRequest < ApplicationRecord
+  belongs_to :user
+  belongs_to :project
+
+  validates :user_id, uniqueness: { scope: :project_id, message: 'has already requested access to this project' }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,11 +21,12 @@ class User < ApplicationRecord
   has_many :memberships, dependent: :destroy
   has_many :projects, through: :memberships, source: :membership, source_type: 'Project'
   has_many :components, through: :memberships, source: :membership, source_type: 'Component'
+  has_many :access_requests, class_name: 'ProjectAccessRequest', dependent: :destroy
 
   scope :alphabetical, -> { order(:name) }
 
   def available_projects
-    admin ? Project.all : projects
+    admin ? Project.all : Project.where(id: projects.pluck(:id)).or(Project.discoverable).distinct
   end
 
   def self.from_omniauth(auth)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
         resources :reviews, only: %i[create]
       end
     end
+    resources :project_access_requests, only: %i[create destroy]
   end
   resources :rule_satisfactions, only: %i[create destroy]
   # Alias rules#index to controls for convenience

--- a/db/migrate/20230623174550_add_visibility_to_projects.rb
+++ b/db/migrate/20230623174550_add_visibility_to_projects.rb
@@ -1,0 +1,5 @@
+class AddVisibilityToProjects < ActiveRecord::Migration[6.1]
+  def change
+    add_column :projects, :visibility, :integer, default: 1
+  end
+end

--- a/db/migrate/20230623174703_add_description_to_projects.rb
+++ b/db/migrate/20230623174703_add_description_to_projects.rb
@@ -1,0 +1,5 @@
+class AddDescriptionToProjects < ActiveRecord::Migration[6.1]
+  def change
+    add_column :projects, :description, :string
+  end
+end

--- a/db/migrate/20230623211457_create_project_access_requests.rb
+++ b/db/migrate/20230623211457_create_project_access_requests.rb
@@ -1,0 +1,12 @@
+class CreateProjectAccessRequests < ActiveRecord::Migration[6.1]
+  def change
+    create_table :project_access_requests do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :project, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :project_access_requests, [:user_id, :project_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_15_180252) do
+ActiveRecord::Schema.define(version: 2023_06_23_211457) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -172,6 +172,16 @@ ActiveRecord::Schema.define(version: 2022_08_15_180252) do
     t.index ["user_id"], name: "index_memberships_on_user_id"
   end
 
+  create_table "project_access_requests", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "project_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["project_id"], name: "index_project_access_requests_on_project_id"
+    t.index ["user_id", "project_id"], name: "index_project_access_requests_on_user_id_and_project_id", unique: true
+    t.index ["user_id"], name: "index_project_access_requests_on_user_id"
+  end
+
   create_table "project_metadata", force: :cascade do |t|
     t.json "data", null: false
     t.bigint "project_id"
@@ -187,6 +197,8 @@ ActiveRecord::Schema.define(version: 2022_08_15_180252) do
     t.integer "memberships_count", default: 0
     t.string "admin_name"
     t.string "admin_email"
+    t.integer "visibility", default: 1
+    t.string "description"
   end
 
   create_table "references", force: :cascade do |t|
@@ -268,6 +280,7 @@ ActiveRecord::Schema.define(version: 2022_08_15_180252) do
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
     t.boolean "admin", default: false
+    t.string "slack_user_id"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
@@ -281,4 +294,6 @@ ActiveRecord::Schema.define(version: 2022_08_15_180252) do
   add_foreign_key "base_rules", "users", column: "review_requestor_id"
   add_foreign_key "components", "components"
   add_foreign_key "memberships", "users"
+  add_foreign_key "project_access_requests", "projects"
+  add_foreign_key "project_access_requests", "users"
 end

--- a/spec/factories/project_access_requests.rb
+++ b/spec/factories/project_access_requests.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :project_access_request do
+    user { nil }
+    project { nil }
+  end
+end


### PR DESCRIPTION
This PR adds the following functionality to Vulcan:
- Enable Admins to setup / edit visibility of a project (discoverable or hidden)
- Allow non-members to search for, see discoverable projects on the project list, and request access to contribute
- Allow admins to accept ( assign a role to the new member) / reject the access request

Fix #590 