### PR TITLE
Fix: Capture STIG Name on Upload

### DIFF
--- a/app/models/security_requirements_guide.rb
+++ b/app/models/security_requirements_guide.rb
@@ -25,8 +25,9 @@ class SecurityRequirementsGuide < ApplicationRecord
               "#{SecurityRequirementsGuide.revision(benchmark_mapping.plaintext.first)}" rescue nil
     release_date = SecurityRequirementsGuide.release_date(benchmark_mapping.plaintext.first)
     # rubocop:enable Style/RescueModifier
-
-    SecurityRequirementsGuide.new(srg_id: id, title: title, version: version, release_date: release_date)
+    name = id&.tr('_', ' ')&.gsub(/(?<=\d)-/, '.')
+    name = "#{name} - Ver #{version.to_s[1]}, Rel #{version.to_s.last}"
+    SecurityRequirementsGuide.new(srg_id: id, title: title, name: name, version: version, release_date: release_date)
   end
 
   # If the SRGs do not conform nicely and this function gets complex, remove the version parse logic

--- a/app/models/stig.rb
+++ b/app/models/stig.rb
@@ -4,7 +4,7 @@
 class Stig < ApplicationRecord
   has_many :stig_rules, dependent: :destroy
 
-  validates :stig_id, :title, :version, :xml, presence: true
+  validates :stig_id, :title, :name, :version, :xml, presence: true
   validates :stig_id, uniqueness: {
     scope: :version,
     message: 'ID has already been taken'
@@ -19,8 +19,11 @@ class Stig < ApplicationRecord
               "#{SecurityRequirementsGuide.revision(benchmark_mapping.plaintext.first)}"
     benchmark_date = SecurityRequirementsGuide.release_date(benchmark_mapping.plaintext.first)
     description = benchmark_mapping&.description&.first
+    name = id&.tr('_', ' ')&.gsub(/(?<=\d)-/, '.')
+    name = "#{name} - Ver #{version.to_s[1]}, Rel #{version.to_s.last}"
 
-    Stig.new(stig_id: id, title: title, version: version, description: description, benchmark_date: benchmark_date)
+    Stig.new(stig_id: id, title: title, name: name, version: version, description: description,
+             benchmark_date: benchmark_date)
   end
 
   def parsed_benchmark

--- a/db/migrate/20230824150144_make_name_not_null_in_stigs.rb
+++ b/db/migrate/20230824150144_make_name_not_null_in_stigs.rb
@@ -1,0 +1,5 @@
+class MakeNameNotNullInStigs < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :stigs, :name, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_08_14_135633) do
+ActiveRecord::Schema.define(version: 2023_08_24_150144) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -276,7 +276,7 @@ ActiveRecord::Schema.define(version: 2023_08_14_135633) do
     t.date "benchmark_date"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.string "name"
+    t.string "name", null: false
     t.index ["stig_id", "version"], name: "stigs_stig_id_version_index", unique: true
   end
 

--- a/lib/tasks/stig_and_srg_puller.rake
+++ b/lib/tasks/stig_and_srg_puller.rake
@@ -72,9 +72,7 @@ namespace :stig_and_srg_puller do
         new_object = model.from_mapping(parsed_benchmark)
         new_object.xml = Nokogiri::XML(xml)
         id = model == Stig ? new_object.stig_id : new_object.srg_id
-        name = id.tr('_', ' ').gsub(/(?<=\d)-/, '.')
-        name = "#{name} - Ver #{new_object.version[1]}, Rel #{new_object.version.last}"
-        new_object.name = item[:file_present] ? item[:name] : name
+
         if new_object.save
           @new_items += 1
           puts "Successfully pulled and saved #{new_object.name}"

--- a/spec/controllers/stigs_controller_spec.rb
+++ b/spec/controllers/stigs_controller_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe StigsController, type: :controller do
       sign_in user
       stig2 = Stig.from_mapping(Xccdf::Benchmark.parse(stig.xml))
       stig2.xml = stig.xml
+      stig2.name = stig.name
       stig2.save!
 
       expect do
@@ -42,6 +43,7 @@ RSpec.describe StigsController, type: :controller do
       sign_in user2
       stig2 = Stig.from_mapping(Xccdf::Benchmark.parse(stig.xml))
       stig2.xml = stig.xml
+      stig2.name = stig.name
       stig2.save!
 
       expect do

--- a/spec/factories/stigs.rb
+++ b/spec/factories/stigs.rb
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
 
-XML_FILE = File.read('./spec/fixtures/files/U_A10_Networks_ADC_ALG_STIG_V2R1_Manual-xccdf.xml')
+XML_FILE_STIG = File.read('./spec/fixtures/files/U_A10_Networks_ADC_ALG_STIG_V2R1_Manual-xccdf.xml')
 
 FactoryBot.define do
   factory :stig do
     stig_id { FFaker::Name.name.underscore }
+    name { FFaker::Name.name }
     title { FFaker::Name.name }
     description { 'MyText' }
     version { "V#{rand(0..9)}R#{rand(0..9)}" }
-    xml { XML_FILE }
+    xml { XML_FILE_STIG }
     benchmark_date { '2023-07-20' }
   end
 end

--- a/spec/models/stig_spec.rb
+++ b/spec/models/stig_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Stig, type: :model do
     it 'validates presence of stig_id, title, version, and xml' do
       expect(stig.stig_id).to be_present
       expect(stig.title).to be_present
+      expect(stig.name).to be_present
       expect(stig.version).to be_present
       expect(stig.xml).to be_present
     end


### PR DESCRIPTION
- Enforced not null constraint on the `name` column of the `stigs` table.
- Updated Stig model to validate the presence of the `name` field.
- Updated `.from_mapping` method of Stig and SecurityRequirementsGuide model to capture the name when initializing the instance
- Updated Stig specs

This will ensure that every STIG has an associated name when created, and prevent display null data on the UI.