### PR TITLE
Added fixref attribute to fixtext XML tag for compatibility with stig-viewer-3x

### DIFF
--- a/app/helpers/export_helper.rb
+++ b/app/helpers/export_helper.rb
@@ -233,7 +233,7 @@ module ExportHelper # rubocop:todo Metrics/ModuleLength
       ox_el_helper(group_rule, 'title', rule[:title])
       descriptions_helper(group_rule, rule)
       ox_el_helper(group_rule, 'ident', rule[:ident], { system: rule[:ident_system] })
-      ox_el_helper(group_rule, 'fixtext', rule[:fixtext])
+      ox_el_helper(group_rule, 'fixtext', rule[:fixtext], { fixref: "F-#{component[:prefix]}-#{rule[:rule_id]}_fix" })
       checks_helper(group_rule, rule)
 
       group << group_rule


### PR DESCRIPTION
Added the XML Attribute and tested the Vulcan XCCDF XML Export with the latest STIG Viewer 3.x.

Attached Screenshots below - 

**Vulcan XCCDF Export generating fixref attribute tags for every rule**

<img width="1523" alt="fixref_generation_xccdf_xml_export_vulcan" src="https://github.com/mitre/vulcan/assets/34048837/c87b68ce-d5f9-4cc0-9a89-0530a556709e">


**STIG Viewer 3.x Displaying the FixText Successfully Without any Issues**

<img width="1712" alt="Jenkins_StigViewer3 x_FixText_Display" src="https://github.com/mitre/vulcan/assets/34048837/86bc02a3-db51-4b74-bd7c-0515356075f6">

<img width="1716" alt="Photon5_StigViewer3 x_FixText_Display" src="https://github.com/mitre/vulcan/assets/34048837/5a8162ab-7ba1-4901-82cc-9a470ebc4c6d">
