### PR TITLE
Enable user to select which component to excel export

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -117,12 +117,12 @@ class ProjectsController < ApplicationController
   end
 
   def export
-    # Using class variable @@components_to_export here to save params[:components_type] value in memory,
+    # Using class variable @@components_to_export here to save params[:component_ids] value in memory,
     # because format.html below triggers a redirect to this same action controller
-    # causing to lose the :components_type param.
+    # causing to lose the :component_ids param.
 
     # rubocop:disable Style/ClassVars
-    @@components_to_export = params[:components_type] || @@components_to_export
+    @@components_to_export = params[:component_ids] || @@components_to_export
     # rubocop:enable Style/ClassVars
 
     export_type = params[:type]&.to_sym

--- a/app/helpers/export_helper.rb
+++ b/app/helpers/export_helper.rb
@@ -32,10 +32,11 @@ module ExportHelper # rubocop:todo Metrics/ModuleLength
     artifact_description: 16
   }.freeze
 
-  def export_excel(project, components_type, is_disa_export)
+  def export_excel(project, component_ids, is_disa_export)
+    components_to_export = project.components.where(id: component_ids.split(','))
     # One file for all data types, each data type in a different tab
     workbook = FastExcel.open(constant_memory: true)
-    components_to_export = components_type == 'all' ? project.components : project.components.where(released: true)
+    # components_to_export = components_type == 'all' ? project.components : project.components.where(released: true)
     components_to_export.eager_load(
       rules: [:reviews, :disa_rule_descriptions, :rule_descriptions, :checks,
               :additional_answers, :satisfies, :satisfied_by, {

--- a/app/javascript/components/project/Project.vue
+++ b/app/javascript/components/project/Project.vue
@@ -118,9 +118,7 @@
                   <template #default="{ ariaDescribedby }">
                     <b-form-checkbox-group
                       v-model="selectedComponentsToExport"
-                      :options="sortedComponents()"
-                      value-field="id"
-                      text-field="name"
+                      :options="excelExportComponentOptions"
                       :aria-describedby="ariaDescribedby"
                       class="mb-2"
                     />
@@ -384,6 +382,12 @@ export default {
     };
   },
   computed: {
+    excelExportComponentOptions: function () {
+      return this.sortedComponents().map((c) => {
+        const versionRelease = c.version && c.release ? ` - V${c.version}R${c.release}` : "";
+        return { text: `${c.name}${versionRelease}`, value: c.id };
+      });
+    },
     sortedAvailableComponents: function () {
       return _.sortBy(this.project.available_components, ["child_project_name"], ["asc"]);
     },

--- a/spec/helpers/export_helper_spec.rb
+++ b/spec/helpers/export_helper_spec.rb
@@ -7,21 +7,14 @@ RSpec.describe ExportHelper, type: :helper do
 
   before(:all) do
     @component = FactoryBot.create(:component)
-    # @released_component = FactoryBot.create(:released_component)
     @project = @component.project
     @component_ids = @project.components.pluck(:id).join(',')
-    # @project_with_released_comp = @released_component.project
   end
 
   describe '#export_excel' do
     before(:all) do
       @workbook = export_excel(@project, @component_ids, false)
-      # @workbook_release_only = export_excel(@project_with_released_comp, 'released', false)
-      # @workbook_release_all = export_excel(@project_with_released_comp, 'all', false)
-
       @workbook_disa_export = export_excel(@project, @component_ids, true)
-      # @workbook_disa_export_release_only = export_excel(@project_with_released_comp, 'released', true)
-      # @workbook_disa_export_release_all = export_excel(@project_with_released_comp, 'all', true)
 
       [@workbook, @workbook_disa_export].each_with_index do |item, index|
         file_name = ''


### PR DESCRIPTION
Vulcan is facing memory issues when attempting to excel export large projects. 
The implemented solution break data export into smaller batches to reduce memory consumption. This is done by allowing users to select which components they would like to export.

![Screenshot 2023-09-25 at 6 43 08 PM](https://github.com/mitre/vulcan/assets/46642178/f7363b6e-91db-45e2-9e08-2520ed14aeaf)

Fix #600 