### PR TITLE
Upgrade to New Heroku Plan

### DIFF
--- a/app.json
+++ b/app.json
@@ -11,7 +11,7 @@
   },
   "environments": {
     "review": {
-      "addons": ["heroku-postgresql:hobby-basic"]
+      "addons": ["heroku-postgresql:essential-0"]
     }
   }
 }


### PR DESCRIPTION
As announced on May 1, 2024, Heroku Postgres mini and basic plans will reach end-of-life (EOL) on May 22, 2024.
Heimdall was using heroku-postgresql:mini.

Make the necessary changes in the app.json, update to the new Essential plan to:
heroku-postgresql:mini → heroku-postgresql:essential-0