### PR TITLE
Update workflow to use artifact actions v4 and update actions/cache f…

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           node-version: '14'
       - name: Cache ruby gems
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
@@ -70,7 +70,7 @@ jobs:
       - name: Run eslint
         run: yarn lint:ci
       - name: Upload coverage results
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: coverage-report


### PR DESCRIPTION
…rom v2 to v4

Changes made
- Updating artifact actions `master` to v4
- actions/cache is recommended to be [updated from v2 to either v3 or v4](https://github.com/actions/cache?tab=readme-ov-file#%EF%B8%8F-important-changes) (picked v4)