### PR TITLE
feat: upgrade preflight toolkit + entrypoint connectivity diagnostics

### DIFF
--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -3,15 +3,137 @@
 # Remove stale PID file if present (prevents "server is already running" errors)
 rm -f /rails/tmp/pids/server.pid
 
-# If running the rails server then create or migrate existing database
-# db:prepare is idempotent: creates DB if missing, runs pending migrations if exists
-# This also triggers admin:bootstrap (hooked into db:prepare)
+# ─── Pre-boot database connectivity check ─────────────────────────────
+# Runs BEFORE Rails boots. Uses pg_isready (no Ruby, no Rails) so it
+# works even when the Rails environment itself can't load due to a
+# misconfigured database connection. On failure, prints diagnostics
+# with exact fix commands instead of a raw PG::ConnectionBad backtrace.
 #
-# IMPORTANT: db:prepare does NOT need DISABLE_DATABASE_ENVIRONMENT_CHECK=1
-# Unlike db:schema:load (rake task), db:prepare calls load_schema() directly
-# as a Ruby method, bypassing the protected environment check entirely.
-# This is by design — see Rails source: DatabaseTasks#initialize_database
-if [[ "$@" == *"server"* ]]; then
+# This is the "gas and go" safety net: if the container can't reach the
+# database, the operator sees actionable output within 10 seconds
+# instead of a cryptic Rails crash.
+# ──────────────────────────────────────────────────────────────────────
+check_database_connectivity() {
+  # Build connection params from the same env vars that database.yml reads
+  if [ -n "$DATABASE_URL" ]; then
+    DB_CHECK_URL="$DATABASE_URL"
+  else
+    local host="${DATABASE_HOST:-127.0.0.1}"
+    local port="${DATABASE_PORT:-5432}"
+    local user="${POSTGRES_USER:-postgres}"
+    local dbname="${POSTGRES_DB:-vulcan_postgres_production}"
+    DB_CHECK_URL="postgres://${user}@${host}:${port}/${dbname}"
+  fi
+
+  # Extract host:port for pg_isready (handles both URL and individual vars)
+  local check_host check_port check_user
+  if [ -n "$DATABASE_URL" ]; then
+    check_host=$(echo "$DATABASE_URL" | sed -E 's|.*@([^:/]+).*|\1|')
+    check_port=$(echo "$DATABASE_URL" | sed -E 's|.*:([0-9]+)/.*|\1|')
+    check_user=$(echo "$DATABASE_URL" | sed -E 's|.*://([^:@]+).*|\1|')
+    [ -z "$check_port" ] && check_port=5432
+  else
+    check_host="${DATABASE_HOST:-127.0.0.1}"
+    check_port="${DATABASE_PORT:-5432}"
+    check_user="${POSTGRES_USER:-postgres}"
+  fi
+
+  echo "Checking database connectivity (${check_host}:${check_port})..."
+
+  # pg_isready is a lightweight TCP + PG protocol check — no auth needed
+  if command -v pg_isready &>/dev/null; then
+    if pg_isready -h "$check_host" -p "$check_port" -U "$check_user" -t 10 &>/dev/null; then
+      echo "  ✓ Database is reachable"
+      return 0
+    fi
+  fi
+
+  # pg_isready failed or not available — try a psql connection test
+  if command -v psql &>/dev/null; then
+    if psql "$DB_CHECK_URL" -c "SELECT 1" &>/dev/null 2>&1; then
+      echo "  ✓ Database is reachable"
+      return 0
+    fi
+  fi
+
+  # ── Connection failed — print diagnostics ──
+  echo ""
+  echo "======================================================================"
+  echo "  ✗ DATABASE CONNECTION FAILED"
+  echo "======================================================================"
+  echo ""
+  echo "  Vulcan cannot reach the database at ${check_host}:${check_port}"
+  echo ""
+  echo "  ── Check these first ──"
+  echo ""
+  if [ -n "$DATABASE_URL" ]; then
+    echo "  DATABASE_URL is set: ${check_host}:${check_port}"
+  else
+    echo "  DATABASE_URL is NOT set (using individual env vars)"
+    echo "    DATABASE_HOST=${DATABASE_HOST:-(not set, defaulting to 127.0.0.1)}"
+    echo "    DATABASE_PORT=${DATABASE_PORT:-(not set, defaulting to 5432)}"
+    echo "    POSTGRES_USER=${POSTGRES_USER:-(not set, defaulting to postgres)}"
+    echo "    POSTGRES_DB=${POSTGRES_DB:-(not set, defaulting to vulcan_postgres_production)}"
+  fi
+  echo ""
+  echo "  ── Common fixes ──"
+  echo ""
+  echo "  1. Is the database host correct?"
+  echo "     • Docker Compose: use 'db' (the service name), not 'localhost'"
+  echo "     • Aurora RDS: use the CLUSTER endpoint, not the instance endpoint"
+  echo "     • Kubernetes: use the service DNS name"
+  echo ""
+  echo "  2. Is SSL required?"
+  echo "     • Aurora/RDS/Cloud SQL require SSL by default"
+  echo "     • Add ?sslmode=require to DATABASE_URL:"
+  echo "       DATABASE_URL=postgres://user:pass@host:5432/dbname?sslmode=require"
+  echo ""
+  echo "  3. Is GSSAPI causing issues?"
+  echo "     • Aurora does not support GSSAPI authentication"
+  echo "     • Set: DATABASE_GSSENCMODE=disable"
+  echo ""
+  echo "  4. Is the database server running?"
+  echo "     • Docker Compose: check 'docker compose ps db'"
+  echo "     • Aurora: check the RDS console for cluster status"
+  echo "     • Firewall/security group blocking port ${check_port}?"
+  echo ""
+  echo "  5. Are credentials correct?"
+  echo "     • Check POSTGRES_USER and POSTGRES_PASSWORD in .env"
+  echo "     • Aurora IAM auth requires a different connection method"
+  echo ""
+  echo "  ── Quick test from this container ──"
+  echo ""
+  echo "  docker compose exec web bash"
+  if [ -n "$DATABASE_URL" ]; then
+    echo "  pg_isready -h ${check_host} -p ${check_port}"
+  else
+    echo "  pg_isready -h \$DATABASE_HOST -p \$DATABASE_PORT"
+  fi
+  echo ""
+  echo "  ── Standalone diagnostic (no Rails needed) ──"
+  echo ""
+  echo "  curl -fsSL https://raw.githubusercontent.com/mitre/vulcan/master/bin/upgrade-check.sh | bash -s -- \"\$DATABASE_URL\""
+  echo ""
+  echo "======================================================================"
+  echo ""
+  return 1
+}
+
+if [[ "$*" == *"server"* ]]; then
+  # Check connectivity BEFORE Rails boots — gives actionable diagnostics
+  # instead of a raw PG::ConnectionBad backtrace
+  if ! check_database_connectivity; then
+    echo "Exiting. Fix the database connection and restart the container."
+    exit 1
+  fi
+
+  # db:prepare is idempotent: creates DB if missing, runs pending migrations if exists
+  # This also triggers admin:bootstrap (hooked into db:prepare)
+  #
+  # IMPORTANT: db:prepare does NOT need DISABLE_DATABASE_ENVIRONMENT_CHECK=1
+  # Unlike db:schema:load (rake task), db:prepare calls load_schema() directly
+  # as a Ruby method, bypassing the protected environment check entirely.
+  # This is by design — see Rails source: DatabaseTasks#initialize_database
   ./bin/rails db:prepare
 fi
 

--- a/bin/upgrade-check.sh
+++ b/bin/upgrade-check.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Vulcan Upgrade Diagnostic — standalone shell script
+#
+# Checks database connectivity and schema state WITHOUT requiring Rails.
+# Use this when you can't install the rake task into a running container.
+#
+# Usage:
+#   ./upgrade-check.sh postgres://user:pass@host:5432/vulcan_production
+#   ./upgrade-check.sh  # uses DATABASE_URL from environment
+#
+# Requirements: psql (PostgreSQL client)
+
+DB_URL="${1:-${DATABASE_URL:-}}"
+
+if [ -z "$DB_URL" ]; then
+  echo "Usage: $0 <DATABASE_URL>"
+  echo "   or: DATABASE_URL=postgres://... $0"
+  echo
+  echo "Example:"
+  echo "  $0 postgres://user:pass@your-cluster.rds.amazonaws.com:5432/vulcan_production?sslmode=require"
+  exit 1
+fi
+
+if ! command -v psql &>/dev/null; then
+  echo "ERROR: psql not found. Install postgresql-client."
+  exit 1
+fi
+
+echo "======================================================================"
+echo "  Vulcan Upgrade Diagnostic (standalone)"
+echo "======================================================================"
+echo
+
+# ── Phase 1: Connection ──
+echo "── Phase 1: Connection ──"
+echo
+
+PG_VERSION=$(psql "$DB_URL" -t -A -c "SELECT version()" 2>&1) || {
+  echo "  ✗ Cannot connect to database"
+  echo
+  echo "  Error: $PG_VERSION"
+  echo
+  echo "  Checklist:"
+  echo "    - Is the hostname correct? (use cluster endpoint for Aurora)"
+  echo "    - Is sslmode=require in the URL? (required for Aurora/RDS)"
+  echo "    - Is the port correct? (default: 5432)"
+  echo "    - Can this machine reach the host? (security group / firewall)"
+  echo "    - Try: psql '$DB_URL' -c 'SELECT 1'"
+  exit 1
+}
+
+echo "  ✓ Connected"
+echo "    $PG_VERSION"
+
+if echo "$PG_VERSION" | grep -qi aurora; then
+  echo "    Runtime: Amazon Aurora"
+fi
+
+# SSL
+SSL_USED=$(psql "$DB_URL" -t -A -c "SELECT CASE WHEN ssl THEN 'yes' ELSE 'no' END FROM pg_stat_ssl WHERE pid = pg_backend_pid()" 2>/dev/null || echo "unknown")
+if [ "$SSL_USED" = "yes" ]; then
+  echo "  ✓ SSL connection active"
+elif [ "$SSL_USED" = "no" ]; then
+  echo "  ⚠ SSL NOT active — add ?sslmode=require for cloud databases"
+else
+  echo "  ℹ SSL status unknown (pg_stat_ssl not available)"
+fi
+
+# Read replica
+IS_REPLICA=$(psql "$DB_URL" -t -A -c "SELECT pg_is_in_recovery()" 2>/dev/null || echo "unknown")
+if [ "$IS_REPLICA" = "t" ]; then
+  echo "  ✗ Database is a READ REPLICA — migrations cannot run"
+  echo "    Use the writer/primary endpoint instead"
+elif [ "$IS_REPLICA" = "f" ]; then
+  echo "  ✓ Database is primary (writable)"
+fi
+
+# Encoding
+ENCODING=$(psql "$DB_URL" -t -A -c "SELECT pg_encoding_to_char(encoding) FROM pg_database WHERE datname = current_database()")
+if [ "$ENCODING" = "UTF8" ]; then
+  echo "  ✓ Encoding: $ENCODING"
+else
+  echo "  ⚠ Encoding: $ENCODING (expected UTF8)"
+fi
+
+# pg_trgm
+if psql "$DB_URL" -t -A -c "SELECT 'test' % 'test'" &>/dev/null; then
+  echo "  ✓ pg_trgm extension available"
+else
+  echo "  ⚠ pg_trgm extension not available (needed for search)"
+  echo "    Aurora: enable in DB parameter group"
+  echo "    Vanilla PG: CREATE EXTENSION IF NOT EXISTS pg_trgm;"
+fi
+
+# ── Phase 2: Schema ──
+echo
+echo "── Phase 2: Schema ──"
+echo
+
+SCHEMA_VERSION=$(psql "$DB_URL" -t -A -c "SELECT MAX(version) FROM schema_migrations" 2>/dev/null || echo "none")
+echo "  Current schema version: $SCHEMA_VERSION"
+
+MIGRATION_COUNT=$(psql "$DB_URL" -t -A -c "SELECT COUNT(*) FROM schema_migrations" 2>/dev/null || echo "0")
+echo "  Applied migrations: $MIGRATION_COUNT"
+
+# ── Phase 3: Data Integrity ──
+echo
+echo "── Phase 3: Data Integrity ──"
+echo
+
+# Check if reviews table exists
+HAS_REVIEWS=$(psql "$DB_URL" -t -A -c "SELECT EXISTS(SELECT 1 FROM information_schema.tables WHERE table_name='reviews')")
+if [ "$HAS_REVIEWS" = "t" ]; then
+  ORPHAN_USERS=$(psql "$DB_URL" -t -A -c "SELECT COUNT(*) FROM reviews WHERE user_id IS NOT NULL AND user_id NOT IN (SELECT id FROM users)")
+  if [ "$ORPHAN_USERS" = "0" ]; then
+    echo "  ✓ No orphaned review.user_id"
+  else
+    echo "  ⚠ $ORPHAN_USERS review(s) with orphaned user_id (migration will nullify)"
+  fi
+
+  ORPHAN_RULES=$(psql "$DB_URL" -t -A -c "SELECT COUNT(*) FROM reviews WHERE rule_id IS NOT NULL AND rule_id NOT IN (SELECT id FROM base_rules)")
+  if [ "$ORPHAN_RULES" = "0" ]; then
+    echo "  ✓ No orphaned review.rule_id"
+  else
+    echo "  ⚠ $ORPHAN_RULES review(s) with orphaned rule_id (migration will delete)"
+  fi
+
+  REVIEW_COUNT=$(psql "$DB_URL" -t -A -c "SELECT COUNT(*) FROM reviews")
+  USER_COUNT=$(psql "$DB_URL" -t -A -c "SELECT COUNT(*) FROM users")
+  RULE_COUNT=$(psql "$DB_URL" -t -A -c "SELECT COUNT(*) FROM base_rules")
+  echo
+  echo "  Table sizes:"
+  echo "    reviews:    $REVIEW_COUNT"
+  echo "    users:      $USER_COUNT"
+  echo "    base_rules: $RULE_COUNT"
+else
+  echo "  ℹ reviews table does not exist (fresh database)"
+fi
+
+AUDIT_COUNT=$(psql "$DB_URL" -t -A -c "SELECT COUNT(*) FROM audits" 2>/dev/null || echo "0")
+echo "    audits:     $AUDIT_COUNT"
+
+# ── Summary ──
+echo
+echo "── Summary ──"
+echo
+echo "  If all checks passed: proceed with the upgrade."
+echo "  If connection failed: fix DATABASE_URL and re-run."
+echo
+echo "  Next steps:"
+echo "    1. Back up: pg_dump -Fc \$DATABASE_URL > backup.dump"
+echo "    2. Upgrade the container image"
+echo "    3. Start the container (db:prepare runs automatically)"
+echo "    4. Verify: rails upgrade:verify (inside the new container)"
+
+if echo "$PG_VERSION" | grep -qi aurora; then
+  echo
+  echo "── Aurora Notes ──"
+  echo "  • Use cluster endpoint (not instance) for DATABASE_URL"
+  echo "  • Add ?sslmode=require to DATABASE_URL"
+  echo "  • Set DATABASE_GSSENCMODE=disable in environment"
+  echo "  • Enable pg_trgm in DB parameter group"
+fi
+
+echo
+echo "======================================================================"

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -189,6 +189,7 @@ export default defineConfig({
             { text: "Bare Metal", link: "/deployment/bare-metal" },
             { text: "Heroku", link: "/deployment/heroku" },
             { text: "Kubernetes", link: "/deployment/kubernetes" },
+            { text: "Upgrade Guide", link: "/deployment/upgrade-guide" },
           ],
         },
         {

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -165,6 +165,21 @@ docker compose run --rm web bundle exec rails db:migrate
 
 > **Why `db:prepare` and not `db:migrate`?** `db:prepare` handles both fresh and existing databases. It is the Rails 8 standard pattern for Docker entrypoints. Unlike `db:schema:load`, `db:prepare` does NOT need `DISABLE_DATABASE_ENVIRONMENT_CHECK` — it calls `load_schema()` as a Ruby method, bypassing the protected environment check by design. See [Rails source: DatabaseTasks#initialize_database](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/tasks/database_tasks.rb) for details.
 
+### Upgrading Between Versions
+
+For major upgrades (e.g., v2.2.x → v2.3.x), run the preflight diagnostic before pulling the new image:
+
+```bash
+# Copy the diagnostic into your running container
+docker cp lib/tasks/upgrade_preflight.rake $(docker compose ps -q web):/rails/lib/tasks/
+docker compose exec web rails upgrade:preflight
+
+# Or use the standalone script (no container modification needed)
+./bin/upgrade-check.sh "$DATABASE_URL"
+```
+
+See the full [Upgrade Guide](upgrade-guide) for step-by-step instructions, Aurora RDS notes, and auto-fix for common data issues.
+
 ## Monitoring
 
 ### Health Check Endpoints

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -167,18 +167,17 @@ docker compose run --rm web bundle exec rails db:migrate
 
 ### Upgrading Between Versions
 
-For major upgrades (e.g., v2.2.x → v2.3.x), run the preflight diagnostic before pulling the new image:
+The upgrade toolkit is built into every image from v2.3.6+:
 
 ```bash
-# Copy the diagnostic into your running container
-docker cp lib/tasks/upgrade_preflight.rake $(docker compose ps -q web):/rails/lib/tasks/
-docker compose exec web rails upgrade:preflight
-
-# Or use the standalone script (no container modification needed)
-./bin/upgrade-check.sh "$DATABASE_URL"
+docker compose pull                                  # Get new image
+docker compose run --rm web rails upgrade:preflight   # Check before upgrading
+docker compose run --rm web rails upgrade:fix         # Fix any issues
+docker compose up -d                                  # Start (runs db:prepare)
+docker compose exec web rails upgrade:verify          # Confirm success
 ```
 
-See the full [Upgrade Guide](upgrade-guide) for step-by-step instructions, Aurora RDS notes, and auto-fix for common data issues.
+See the full [Upgrade Guide](upgrade-guide) for Aurora RDS notes, Kubernetes/ECS paths, and troubleshooting.
 
 ## Monitoring
 

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -23,6 +23,8 @@ Choose the deployment method that fits your infrastructure and team.
 
 **Enterprise / multi-tenant?** [Kubernetes](kubernetes) with Helm chart for scaling and isolation.
 
+**Upgrading from an older version?** See the [Upgrade Guide](upgrade-guide) — includes a preflight diagnostic, auto-fix for common data issues, and Aurora RDS guidance.
+
 **Air-gapped / classified network?** [Bare Metal](bare-metal) for full control without container dependencies.
 
 ## Common Requirements (All Deployments)

--- a/docs/deployment/upgrade-guide.md
+++ b/docs/deployment/upgrade-guide.md
@@ -1,8 +1,14 @@
 # Vulcan Upgrade Guide
 
+## How it works
+
+From v2.3.6+, the Docker entrypoint automatically tests the database connection **before** Rails boots. If the connection fails, you get a plain-English diagnostic with exact fix commands — not a Ruby backtrace.
+
+If the connection succeeds, `db:prepare` runs pending migrations and the server starts.
+
 ## Quick Start
 
-The upgrade toolkit is built into every Vulcan image from v2.3.6+. No file injection, no extra installs — just pull and run.
+Just pull the new image and start. The container tells you what's wrong.
 
 ### Docker Compose (most common)
 

--- a/docs/deployment/upgrade-guide.md
+++ b/docs/deployment/upgrade-guide.md
@@ -1,0 +1,185 @@
+# Vulcan Upgrade Guide
+
+## Quick Start (for any version upgrade)
+
+### Step 1: Install the upgrade toolkit
+
+If you're on an older release (before the toolkit was merged), drop the rake file into your existing install:
+
+```bash
+# Option A: Download directly from GitHub
+curl -fsSL https://raw.githubusercontent.com/mitre/vulcan/master/lib/tasks/upgrade_preflight.rake \
+  -o lib/tasks/upgrade_preflight.rake
+
+# Option B: From the tarball (if someone sent you the package)
+tar -xzf vulcan-upgrade-toolkit.tar.gz
+```
+
+No gem installs, no Gemfile changes — it's one file that uses Rails and PostgreSQL APIs already in your app.
+
+### Step 2: Back up your database
+
+**Do this before anything else.** Every upgrade path is tested, but your data is unique.
+
+```bash
+# Vanilla PostgreSQL
+pg_dump -Fc your_database > vulcan_backup_$(date +%Y%m%d).dump
+
+# Aurora RDS (from a bastion or local machine with psql access)
+pg_dump -Fc -h your-cluster.cluster-xxxx.us-east-1.rds.amazonaws.com \
+  -U vulcan_user -d vulcan_production > vulcan_backup_$(date +%Y%m%d).dump
+
+# Docker Compose
+docker compose exec db pg_dump -Fc -U postgres vulcan_postgres_production \
+  > vulcan_backup_$(date +%Y%m%d).dump
+```
+
+### Step 3: Run the preflight check
+
+```bash
+# Bare metal / systemd
+bundle exec rails upgrade:preflight
+
+# Docker Compose (existing container)
+docker compose exec web rails upgrade:preflight
+
+# Docker (new image, existing database)
+docker run --rm --env-file .env vulcan:new-version rails upgrade:preflight
+```
+
+The preflight reports:
+- ✓ = good
+- ⚠ = warning (review, but won't block)
+- ✗ = blocker (must fix before upgrading)
+
+### Step 4: Fix any issues
+
+```bash
+# Auto-fix safe issues (orphaned records, counter caches, missing dirs)
+bundle exec rails upgrade:fix
+
+# Or in Docker
+docker compose exec web rails upgrade:fix
+```
+
+The fix task only runs **safe, reversible operations** — it will NOT:
+- Delete data without telling you exactly what and how many rows
+- Modify schema (that's what db:prepare does)
+- Change configuration (it tells you what to set)
+
+For connection issues (the most common upgrade blocker), the fix task prints the exact environment variables you need to set.
+
+### Step 5: Run the upgrade
+
+```bash
+# This runs pending migrations (safe — preflight already validated)
+bundle exec rails db:prepare
+
+# Docker: the entrypoint does this automatically on container start
+docker compose up
+```
+
+### Step 6: Verify
+
+```bash
+bundle exec rails upgrade:verify
+# or
+docker compose exec web rails upgrade:verify
+```
+
+---
+
+## Common Upgrade Scenarios
+
+### Upgrading from v2.2.x to v2.3.x
+
+This is a large jump (~90 migrations). Key changes:
+
+| Version | What changed | Migration risk |
+|---|---|---|
+| v2.3.0 | Devise lockable, sessions table | Low — additive columns |
+| v2.3.1 | OIDC provider fix, auth improvements | Low |
+| v2.3.4 | Blueprinter JSON serialization | Low — no schema changes |
+| v2.3.5 | Public comment review (PR-717) | **Medium** — 8 new columns on reviews, 6 FK constraints, orphan cleanup |
+| v2.3.6 | Reactions, UBI9 Docker base | Low — 1 new table |
+
+The **v2.3.5 migrations** are the ones most likely to surface data issues:
+- Reviews referencing deleted users → automatically nullified
+- Reviews referencing deleted rules → automatically deleted
+- Reviews referencing deleted parent reviews → **blocks migration** (run `upgrade:fix`)
+
+### Aurora RDS Specific
+
+Aurora PostgreSQL is fully supported. Common connection issues:
+
+```bash
+# Required environment variables for Aurora
+DATABASE_URL=postgres://user:pass@your-cluster.cluster-xxxx.rds.amazonaws.com:5432/vulcan_production?sslmode=require
+DATABASE_GSSENCMODE=disable
+```
+
+**Checklist:**
+- [ ] Use the **cluster endpoint** (not instance endpoint) — survives failover
+- [ ] Add `?sslmode=require` to DATABASE_URL (Aurora enforces SSL)
+- [ ] Set `DATABASE_GSSENCMODE=disable` (Aurora doesn't support GSSAPI)
+- [ ] Enable `pg_trgm` in your Aurora DB parameter group (needed for search)
+- [ ] If using a custom CA: add the [RDS CA bundle](https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem) to `certs/`
+
+### Docker Image Change (v2.3.6+)
+
+The base image changed from Debian (`ruby:3.4.9-slim`) to Red Hat UBI 9 (`ubi-minimal:9.7`). This affects:
+
+- **SSL cert paths**: `/etc/ssl/certs/ca-certificates.crt` → `/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem`
+- **Package manager**: `apt-get` → `microdnf` (only matters if you customized the Dockerfile)
+- **PostgreSQL volume mount**: `/var/lib/postgresql/data` → `/var/lib/postgresql` (Postgres 18)
+
+**If upgrading docker-compose with existing data:**
+```bash
+# 1. Stop the stack
+docker compose down
+
+# 2. Back up (see Step 2 above)
+
+# 3. If using Postgres 18 with old volume:
+#    The volume mount path changed. Your options:
+#    a) Back up + restore into a fresh volume (safest)
+#    b) Or keep the old mount path by overriding in docker-compose:
+#       volumes:
+#         - vulcan_dbdata:/var/lib/postgresql/data
+
+# 4. Start with new image
+docker compose up
+```
+
+---
+
+## Troubleshooting
+
+### "not seeing the db" / connection refused
+
+Run `upgrade:preflight` — Phase 1 checks connectivity and reports exactly what's wrong. Most common causes:
+
+1. **DATABASE_URL not set** (or set to the wrong host)
+2. **SSL not configured** for cloud databases
+3. **GSSAPI negotiation failure** (set `DATABASE_GSSENCMODE=disable`)
+4. **Read replica endpoint** instead of writer endpoint
+5. **Security group / firewall** blocking port 5432
+
+### Migration fails mid-way
+
+The preflight task catches most issues before they happen. If a migration does fail:
+
+1. Check the error message — it usually names the constraint or column
+2. Run `upgrade:preflight` again (it re-checks from current state)
+3. Run `upgrade:fix` to remediate data issues
+4. Re-run `rails db:prepare` (idempotent — picks up where it left off)
+
+### Counter cache drift after upgrade
+
+If the UI shows wrong rule counts after upgrading:
+
+```bash
+rails runner "Component.find_each { |c| Component.reset_counters(c.id, :rules) }"
+```
+
+Or use `upgrade:verify` which spot-checks and reports drift.

--- a/docs/deployment/upgrade-guide.md
+++ b/docs/deployment/upgrade-guide.md
@@ -108,7 +108,7 @@ bundle exec rails upgrade:fix
 docker compose exec web rails upgrade:fix
 ```
 
-The fix task only runs **safe, reversible operations** — it will NOT:
+The fix task only runs **safe operations** — it will NOT:
 - Delete data without telling you exactly what and how many rows
 - Modify schema (that's what db:prepare does)
 - Change configuration (it tells you what to set)

--- a/docs/deployment/upgrade-guide.md
+++ b/docs/deployment/upgrade-guide.md
@@ -4,18 +4,57 @@
 
 ### Step 1: Install the upgrade toolkit
 
-If you're on an older release (before the toolkit was merged), drop the rake file into your existing install:
+Choose the method that matches your deployment:
+
+#### Bare metal / systemd
 
 ```bash
-# Option A: Download directly from GitHub
+# Download directly into your Vulcan source tree
+cd /path/to/vulcan
 curl -fsSL https://raw.githubusercontent.com/mitre/vulcan/master/lib/tasks/upgrade_preflight.rake \
   -o lib/tasks/upgrade_preflight.rake
-
-# Option B: From the tarball (if someone sent you the package)
-tar -xzf vulcan-upgrade-toolkit.tar.gz
 ```
 
-No gem installs, no Gemfile changes — it's one file that uses Rails and PostgreSQL APIs already in your app.
+#### Docker Compose
+
+```bash
+# Copy the rake file into your RUNNING container (no image rebuild needed)
+curl -fsSL https://raw.githubusercontent.com/mitre/vulcan/master/lib/tasks/upgrade_preflight.rake \
+  -o /tmp/upgrade_preflight.rake
+docker cp /tmp/upgrade_preflight.rake $(docker compose ps -q web):/rails/lib/tasks/upgrade_preflight.rake
+```
+
+#### ECS / Kubernetes / any container orchestrator
+
+```bash
+# Option A: Exec into the running task/pod and download
+kubectl exec -it deploy/vulcan-web -- bash -c \
+  "curl -fsSL https://raw.githubusercontent.com/mitre/vulcan/master/lib/tasks/upgrade_preflight.rake \
+   -o lib/tasks/upgrade_preflight.rake"
+
+# Option B: If curl isn't available in the container, copy from local
+kubectl cp /tmp/upgrade_preflight.rake vulcan-web-pod:/rails/lib/tasks/upgrade_preflight.rake
+
+# ECS equivalent (using aws cli + ssm exec)
+aws ecs execute-command --cluster vulcan --task $TASK_ID --container web \
+  --command "curl -fsSL https://raw.githubusercontent.com/mitre/vulcan/master/lib/tasks/upgrade_preflight.rake \
+  -o lib/tasks/upgrade_preflight.rake" --interactive
+```
+
+#### Can't modify the container at all?
+
+Use the standalone diagnostic script — no Rails required, just `psql`:
+
+```bash
+# Download and run from any machine that can reach your database
+curl -fsSL https://raw.githubusercontent.com/mitre/vulcan/master/bin/upgrade-check.sh \
+  -o upgrade-check.sh && chmod +x upgrade-check.sh
+
+# Point it at your database
+./upgrade-check.sh postgres://user:pass@your-db-host:5432/vulcan_production
+```
+
+No gem installs, no Gemfile changes, no image rebuilds. The rake task is one file that uses Rails APIs already in the app. The shell script uses only `psql`.
 
 ### Step 2: Back up your database
 
@@ -32,6 +71,10 @@ pg_dump -Fc -h your-cluster.cluster-xxxx.us-east-1.rds.amazonaws.com \
 # Docker Compose
 docker compose exec db pg_dump -Fc -U postgres vulcan_postgres_production \
   > vulcan_backup_$(date +%Y%m%d).dump
+
+# ECS / Kubernetes (exec into the db container or use a bastion)
+kubectl exec -it deploy/vulcan-db -- pg_dump -Fc -U postgres vulcan_production \
+  > vulcan_backup_$(date +%Y%m%d).dump
 ```
 
 ### Step 3: Run the preflight check
@@ -40,11 +83,14 @@ docker compose exec db pg_dump -Fc -U postgres vulcan_postgres_production \
 # Bare metal / systemd
 bundle exec rails upgrade:preflight
 
-# Docker Compose (existing container)
+# Docker Compose
 docker compose exec web rails upgrade:preflight
 
-# Docker (new image, existing database)
+# Docker (new image against existing database)
 docker run --rm --env-file .env vulcan:new-version rails upgrade:preflight
+
+# ECS / Kubernetes
+kubectl exec -it deploy/vulcan-web -- rails upgrade:preflight
 ```
 
 The preflight reports:

--- a/docs/deployment/upgrade-guide.md
+++ b/docs/deployment/upgrade-guide.md
@@ -1,137 +1,116 @@
 # Vulcan Upgrade Guide
 
-## Quick Start (for any version upgrade)
+## Quick Start
 
-### Step 1: Install the upgrade toolkit
+The upgrade toolkit is built into every Vulcan image from v2.3.6+. No file injection, no extra installs — just pull and run.
 
-Choose the method that matches your deployment:
-
-#### Bare metal / systemd
+### Docker Compose (most common)
 
 ```bash
-# Download directly into your Vulcan source tree
-cd /path/to/vulcan
-curl -fsSL https://raw.githubusercontent.com/mitre/vulcan/master/lib/tasks/upgrade_preflight.rake \
-  -o lib/tasks/upgrade_preflight.rake
-```
-
-#### Docker Compose
-
-```bash
-# Copy the rake file into your RUNNING container (no image rebuild needed)
-curl -fsSL https://raw.githubusercontent.com/mitre/vulcan/master/lib/tasks/upgrade_preflight.rake \
-  -o /tmp/upgrade_preflight.rake
-docker cp /tmp/upgrade_preflight.rake $(docker compose ps -q web):/rails/lib/tasks/upgrade_preflight.rake
-```
-
-#### ECS / Kubernetes / any container orchestrator
-
-```bash
-# Option A: Exec into the running task/pod and download
-kubectl exec -it deploy/vulcan-web -- bash -c \
-  "curl -fsSL https://raw.githubusercontent.com/mitre/vulcan/master/lib/tasks/upgrade_preflight.rake \
-   -o lib/tasks/upgrade_preflight.rake"
-
-# Option B: If curl isn't available in the container, copy from local
-kubectl cp /tmp/upgrade_preflight.rake vulcan-web-pod:/rails/lib/tasks/upgrade_preflight.rake
-
-# ECS equivalent (using aws cli + ssm exec)
-aws ecs execute-command --cluster vulcan --task $TASK_ID --container web \
-  --command "curl -fsSL https://raw.githubusercontent.com/mitre/vulcan/master/lib/tasks/upgrade_preflight.rake \
-  -o lib/tasks/upgrade_preflight.rake" --interactive
-```
-
-#### Can't modify the container at all?
-
-Use the standalone diagnostic script — no Rails required, just `psql`:
-
-```bash
-# Download and run from any machine that can reach your database
-curl -fsSL https://raw.githubusercontent.com/mitre/vulcan/master/bin/upgrade-check.sh \
-  -o upgrade-check.sh && chmod +x upgrade-check.sh
-
-# Point it at your database
-./upgrade-check.sh postgres://user:pass@your-db-host:5432/vulcan_production
-```
-
-No gem installs, no Gemfile changes, no image rebuilds. The rake task is one file that uses Rails APIs already in the app. The shell script uses only `psql`.
-
-### Step 2: Back up your database
-
-**Do this before anything else.** Every upgrade path is tested, but your data is unique.
-
-```bash
-# Vanilla PostgreSQL
-pg_dump -Fc your_database > vulcan_backup_$(date +%Y%m%d).dump
-
-# Aurora RDS (from a bastion or local machine with psql access)
-pg_dump -Fc -h your-cluster.cluster-xxxx.us-east-1.rds.amazonaws.com \
-  -U vulcan_user -d vulcan_production > vulcan_backup_$(date +%Y%m%d).dump
-
-# Docker Compose
+# 1. Back up your database
 docker compose exec db pg_dump -Fc -U postgres vulcan_postgres_production \
   > vulcan_backup_$(date +%Y%m%d).dump
 
-# ECS / Kubernetes (exec into the db container or use a bastion)
-kubectl exec -it deploy/vulcan-db -- pg_dump -Fc -U postgres vulcan_production \
-  > vulcan_backup_$(date +%Y%m%d).dump
+# 2. Pull the new image (or update your image tag in docker-compose.yml)
+docker compose pull
+
+# 3. Preflight check (runs the NEW image against your EXISTING database)
+docker compose run --rm web rails upgrade:preflight
+
+# 4. Fix any issues it finds
+docker compose run --rm web rails upgrade:fix
+
+# 5. Start (db:prepare runs automatically via the entrypoint)
+docker compose up -d
+
+# 6. Verify
+docker compose exec web rails upgrade:verify
 ```
 
-### Step 3: Run the preflight check
+### Kubernetes / ECS
 
 ```bash
-# Bare metal / systemd
+# 1. Back up your database (use your standard backup procedure)
+
+# 2. Run preflight as a one-shot pod/task with the NEW image
+kubectl run vulcan-preflight --rm -it \
+  --image=mitre/vulcan:v2.3.6 \
+  --env-from=secret/vulcan-env \
+  -- rails upgrade:preflight
+
+# 3. Fix if needed
+kubectl run vulcan-fix --rm -it \
+  --image=mitre/vulcan:v2.3.6 \
+  --env-from=secret/vulcan-env \
+  -- rails upgrade:fix
+
+# 4. Deploy the new image (your standard deploy process)
+# 5. Verify
+kubectl exec -it deploy/vulcan-web -- rails upgrade:verify
+```
+
+### Bare metal / systemd
+
+```bash
+# 1. Back up
+pg_dump -Fc your_database > vulcan_backup_$(date +%Y%m%d).dump
+
+# 2. Pull new code
+cd /path/to/vulcan && git pull
+
+# 3. Preflight
 bundle exec rails upgrade:preflight
 
-# Docker Compose
-docker compose exec web rails upgrade:preflight
+# 4. Fix
+bundle exec rails upgrade:fix
 
-# Docker (new image against existing database)
-docker run --rm --env-file .env vulcan:new-version rails upgrade:preflight
+# 5. Upgrade
+bundle exec rails db:prepare
 
-# ECS / Kubernetes
-kubectl exec -it deploy/vulcan-web -- rails upgrade:preflight
+# 6. Verify
+bundle exec rails upgrade:verify
 ```
+
+### Can't even connect? (quick diagnostic)
+
+If the new container won't start at all, use the standalone script from any machine with `psql`:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/mitre/vulcan/master/bin/upgrade-check.sh -o upgrade-check.sh
+chmod +x upgrade-check.sh
+./upgrade-check.sh "postgres://user:pass@your-db-host:5432/vulcan_production?sslmode=require"
+```
+
+No Rails, no Ruby, no container — just raw database diagnostics.
+
+### What the tools do
+
+| Command | When | What |
+|---|---|---|
+| `rails upgrade:preflight` | Before upgrade | Checks connectivity, SSL, schema, orphaned data, config (read-only) |
+| `rails upgrade:fix` | Before upgrade | Fixes orphaned records, counter caches, missing dirs (safe writes) |
+| `rails upgrade:verify` | After upgrade | Validates schema, models, routes, assets, admin user |
+| `bin/upgrade-check.sh` | Can't start container | Raw psql diagnostic — tests connection, SSL, encoding |
 
 The preflight reports:
 - ✓ = good
 - ⚠ = warning (review, but won't block)
 - ✗ = blocker (must fix before upgrading)
 
-### Step 4: Fix any issues
+### Upgrading from pre-v2.3.6 (toolkit not in image)
+
+If your CURRENT image doesn't have the toolkit yet, run the preflight from the NEW image:
 
 ```bash
-# Auto-fix safe issues (orphaned records, counter caches, missing dirs)
-bundle exec rails upgrade:fix
+# Pull the new image but don't start it yet
+docker pull mitre/vulcan:v2.3.6
 
-# Or in Docker
-docker compose exec web rails upgrade:fix
+# Run preflight from the new image against your existing database
+docker run --rm --env-file .env mitre/vulcan:v2.3.6 rails upgrade:preflight
+docker run --rm --env-file .env mitre/vulcan:v2.3.6 rails upgrade:fix
 ```
 
-The fix task only runs **safe operations** — it will NOT:
-- Delete data without telling you exactly what and how many rows
-- Modify schema (that's what db:prepare does)
-- Change configuration (it tells you what to set)
-
-For connection issues (the most common upgrade blocker), the fix task prints the exact environment variables you need to set.
-
-### Step 5: Run the upgrade
-
-```bash
-# This runs pending migrations (safe — preflight already validated)
-bundle exec rails db:prepare
-
-# Docker: the entrypoint does this automatically on container start
-docker compose up
-```
-
-### Step 6: Verify
-
-```bash
-bundle exec rails upgrade:verify
-# or
-docker compose exec web rails upgrade:verify
-```
+The `--env-file .env` passes your existing database credentials to the new container.
 
 ---
 

--- a/lib/tasks/upgrade_preflight.rake
+++ b/lib/tasks/upgrade_preflight.rake
@@ -556,4 +556,170 @@ namespace :upgrade do
     puts '=' * 70
     exit(issues.any? ? 1 : 0)
   end
+
+  # =====================================================================
+  # Safe Auto-Remediation
+  # =====================================================================
+  desc 'Fix safe issues found by upgrade:preflight (orphans, counter caches, dirs)'
+  task fix: :environment do
+    puts '=' * 70
+    puts "  Vulcan Upgrade Fix — #{Time.current.strftime('%Y-%m-%d %H:%M:%S %Z')}"
+    puts '=' * 70
+    puts
+    puts '  This task fixes SAFE, REVERSIBLE issues only.'
+    puts '  It will NOT modify schema or delete user-visible data without reporting.'
+    puts
+
+    conn = ActiveRecord::Base.connection
+    fixed = 0
+
+    # ── Writable directories ──
+    puts '── Directories ──'
+    %w[tmp log storage db].each do |dir|
+      path = Rails.root.join(dir)
+      next if path.exist?
+
+      FileUtils.mkdir_p(path)
+      puts "  ✓ Created #{dir}/"
+      fixed += 1
+    end
+    puts '  ✓ All required directories exist' if fixed.zero?
+
+    # ── pg_trgm extension ──
+    puts
+    puts '── Extensions ──'
+    begin
+      conn.exec_query("SELECT 'test' % 'test'")
+      puts '  ✓ pg_trgm already available'
+    rescue StandardError
+      begin
+        conn.exec_query('CREATE EXTENSION IF NOT EXISTS pg_trgm')
+        puts '  ✓ pg_trgm extension installed'
+        fixed += 1
+      rescue StandardError => e
+        puts "  ✗ Cannot install pg_trgm: #{e.message}"
+        puts '    For Aurora: enable pg_trgm in the DB parameter group manually'
+      end
+    end
+
+    # ── Orphaned data (only if reviews table exists) ──
+    if conn.table_exists?(:reviews)
+      puts
+      puts '── Data Integrity Fixes ──'
+
+      # Orphaned review.user_id → nullify
+      orphan_users = conn.exec_query(
+        'SELECT COUNT(*) AS c FROM reviews WHERE user_id IS NOT NULL AND user_id NOT IN (SELECT id FROM users)'
+      ).first['c'].to_i
+      if orphan_users.positive?
+        conn.exec_update(
+          'UPDATE reviews SET user_id = NULL WHERE user_id IS NOT NULL AND user_id NOT IN (SELECT id FROM users)'
+        )
+        puts "  ✓ Nullified #{orphan_users} review(s) with orphaned user_id (users were deleted)"
+        fixed += 1
+      else
+        puts '  ✓ No orphaned review.user_id references'
+      end
+
+      # Orphaned review.rule_id → delete (these reviews reference deleted rules)
+      orphan_rules = conn.exec_query(
+        'SELECT COUNT(*) AS c FROM reviews WHERE rule_id IS NOT NULL AND rule_id NOT IN (SELECT id FROM base_rules)'
+      ).first['c'].to_i
+      if orphan_rules.positive?
+        puts "  ⚠ #{orphan_rules} review(s) reference deleted rules"
+        puts '    These will be DELETED (the rules no longer exist — these reviews are orphaned)'
+        puts '    Proceeding...'
+        conn.exec_delete(
+          'DELETE FROM reviews WHERE rule_id IS NOT NULL AND rule_id NOT IN (SELECT id FROM base_rules)'
+        )
+        puts "  ✓ Deleted #{orphan_rules} orphaned review(s)"
+        fixed += 1
+      else
+        puts '  ✓ No orphaned review.rule_id references'
+      end
+
+      # Orphaned responding_to_review_id → delete
+      if conn.column_exists?(:reviews, :responding_to_review_id)
+        orphan_parents = conn.exec_query(
+          'SELECT COUNT(*) AS c FROM reviews WHERE responding_to_review_id IS NOT NULL ' \
+          'AND responding_to_review_id NOT IN (SELECT id FROM reviews)'
+        ).first['c'].to_i
+        if orphan_parents.positive?
+          puts "  ⚠ #{orphan_parents} review(s) reference deleted parent reviews"
+          puts '    These replies are orphaned (parent comment was deleted)'
+          conn.exec_delete(
+            'DELETE FROM reviews WHERE responding_to_review_id IS NOT NULL ' \
+            'AND responding_to_review_id NOT IN (SELECT id FROM reviews)'
+          )
+          puts "  ✓ Deleted #{orphan_parents} orphaned reply/replies"
+          fixed += 1
+        else
+          puts '  ✓ No orphaned review.responding_to_review_id references'
+        end
+      end
+    end
+
+    # ── Orphaned components ──
+    if conn.table_exists?(:components)
+      orphan_components = conn.exec_query(
+        'SELECT COUNT(*) AS c FROM components WHERE project_id IS NOT NULL AND project_id NOT IN (SELECT id FROM projects)'
+      ).first['c'].to_i
+      if orphan_components.positive?
+        puts "  ⚠ #{orphan_components} component(s) reference deleted projects — skipping (manual review needed)"
+      else
+        puts '  ✓ No orphaned component.project_id references'
+      end
+    end
+
+    # ── Counter cache drift ──
+    if conn.table_exists?(:components) && conn.column_exists?(:components, :rules_count)
+      puts
+      puts '── Counter Cache ──'
+      drift_count = conn.exec_query(
+        "SELECT COUNT(*) AS c FROM components WHERE rules_count != (SELECT COUNT(*) FROM base_rules WHERE base_rules.component_id = components.id AND base_rules.type = 'Rule')"
+      ).first['c'].to_i
+      if drift_count.positive?
+        Component.find_each { |c| Component.reset_counters(c.id, :rules) }
+        puts "  ✓ Reset rules_count on #{drift_count} component(s)"
+        fixed += 1
+      else
+        puts '  ✓ Counter caches are accurate'
+      end
+    end
+
+    # ── Connection configuration guidance ──
+    puts
+    puts '── Configuration Guidance ──'
+    puts
+
+    if ENV['DATABASE_URL'].blank? && ENV['DATABASE_HOST'].blank?
+      puts '  DATABASE_URL is not set. For production, set it to:'
+      puts
+      puts '    # Standard PostgreSQL'
+      puts '    DATABASE_URL=postgres://user:pass@host:5432/vulcan_production'
+      puts
+      puts '    # Aurora RDS (add sslmode=require)'
+      puts '    DATABASE_URL=postgres://user:pass@cluster.xxxx.rds.amazonaws.com:5432/vulcan_production?sslmode=require'
+      puts
+    end
+
+    gss = ENV.fetch('DATABASE_GSSENCMODE', 'prefer')
+    if gss != 'disable'
+      puts '  For cloud databases (Aurora, RDS, Cloud SQL), add to your .env:'
+      puts '    DATABASE_GSSENCMODE=disable'
+      puts
+    end
+
+    # ── Summary ──
+    puts '── Summary ──'
+    puts
+    if fixed.positive?
+      puts "  ✓ #{fixed} issue(s) fixed. Run upgrade:preflight again to verify."
+    else
+      puts '  ✓ No fixable issues found. Ready for: rails db:prepare'
+    end
+
+    puts
+    puts '=' * 70
+  end
 end

--- a/lib/tasks/upgrade_preflight.rake
+++ b/lib/tasks/upgrade_preflight.rake
@@ -566,8 +566,9 @@ namespace :upgrade do
     puts "  Vulcan Upgrade Fix — #{Time.current.strftime('%Y-%m-%d %H:%M:%S %Z')}"
     puts '=' * 70
     puts
-    puts '  This task fixes SAFE, REVERSIBLE issues only.'
-    puts '  It will NOT modify schema or delete user-visible data without reporting.'
+    puts '  This task fixes SAFE issues only.'
+    puts '  It will NOT modify schema. Orphan deletions are reported with counts.'
+    puts '  BACK UP YOUR DATABASE FIRST if you have not already.'
     puts
 
     conn = ActiveRecord::Base.connection
@@ -607,54 +608,60 @@ namespace :upgrade do
       puts
       puts '── Data Integrity Fixes ──'
 
+      # Each orphan fix runs inside a transaction so the count and
+      # mutation are atomic (no TOCTOU race with concurrent requests).
+
       # Orphaned review.user_id → nullify
-      orphan_users = conn.exec_query(
-        'SELECT COUNT(*) AS c FROM reviews WHERE user_id IS NOT NULL AND user_id NOT IN (SELECT id FROM users)'
-      ).first['c'].to_i
-      if orphan_users.positive?
-        conn.exec_update(
-          'UPDATE reviews SET user_id = NULL WHERE user_id IS NOT NULL AND user_id NOT IN (SELECT id FROM users)'
-        )
-        puts "  ✓ Nullified #{orphan_users} review(s) with orphaned user_id (users were deleted)"
-        fixed += 1
-      else
-        puts '  ✓ No orphaned review.user_id references'
+      ActiveRecord::Base.transaction do
+        orphan_users = conn.exec_query(
+          'SELECT COUNT(*) AS c FROM reviews WHERE user_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM users WHERE users.id = reviews.user_id)'
+        ).first['c'].to_i
+        if orphan_users.positive?
+          conn.exec_update(
+            'UPDATE reviews SET user_id = NULL WHERE user_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM users WHERE users.id = reviews.user_id)'
+          )
+          puts "  ✓ Nullified #{orphan_users} review(s) with orphaned user_id (users were deleted)"
+          fixed += 1
+        else
+          puts '  ✓ No orphaned review.user_id references'
+        end
       end
 
-      # Orphaned review.rule_id → delete (these reviews reference deleted rules)
-      orphan_rules = conn.exec_query(
-        'SELECT COUNT(*) AS c FROM reviews WHERE rule_id IS NOT NULL AND rule_id NOT IN (SELECT id FROM base_rules)'
-      ).first['c'].to_i
-      if orphan_rules.positive?
-        puts "  ⚠ #{orphan_rules} review(s) reference deleted rules"
-        puts '    These will be DELETED (the rules no longer exist — these reviews are orphaned)'
-        puts '    Proceeding...'
-        conn.exec_delete(
-          'DELETE FROM reviews WHERE rule_id IS NOT NULL AND rule_id NOT IN (SELECT id FROM base_rules)'
-        )
-        puts "  ✓ Deleted #{orphan_rules} orphaned review(s)"
-        fixed += 1
-      else
-        puts '  ✓ No orphaned review.rule_id references'
+      # Orphaned review.rule_id → delete
+      ActiveRecord::Base.transaction do
+        orphan_rules = conn.exec_query(
+          'SELECT COUNT(*) AS c FROM reviews WHERE rule_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM base_rules WHERE base_rules.id = reviews.rule_id)'
+        ).first['c'].to_i
+        if orphan_rules.positive?
+          puts "  ⚠ #{orphan_rules} review(s) reference deleted rules — DELETING"
+          conn.exec_delete(
+            'DELETE FROM reviews WHERE rule_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM base_rules WHERE base_rules.id = reviews.rule_id)'
+          )
+          puts "  ✓ Deleted #{orphan_rules} orphaned review(s)"
+          fixed += 1
+        else
+          puts '  ✓ No orphaned review.rule_id references'
+        end
       end
 
       # Orphaned responding_to_review_id → delete
       if conn.column_exists?(:reviews, :responding_to_review_id)
-        orphan_parents = conn.exec_query(
-          'SELECT COUNT(*) AS c FROM reviews WHERE responding_to_review_id IS NOT NULL ' \
-          'AND responding_to_review_id NOT IN (SELECT id FROM reviews)'
-        ).first['c'].to_i
-        if orphan_parents.positive?
-          puts "  ⚠ #{orphan_parents} review(s) reference deleted parent reviews"
-          puts '    These replies are orphaned (parent comment was deleted)'
-          conn.exec_delete(
-            'DELETE FROM reviews WHERE responding_to_review_id IS NOT NULL ' \
-            'AND responding_to_review_id NOT IN (SELECT id FROM reviews)'
-          )
-          puts "  ✓ Deleted #{orphan_parents} orphaned reply/replies"
-          fixed += 1
-        else
-          puts '  ✓ No orphaned review.responding_to_review_id references'
+        ActiveRecord::Base.transaction do
+          orphan_parents = conn.exec_query(
+            'SELECT COUNT(*) AS c FROM reviews WHERE responding_to_review_id IS NOT NULL ' \
+            'AND NOT EXISTS (SELECT 1 FROM reviews r2 WHERE r2.id = reviews.responding_to_review_id)'
+          ).first['c'].to_i
+          if orphan_parents.positive?
+            puts "  ⚠ #{orphan_parents} orphaned parent review references — DELETING"
+            conn.exec_delete(
+              'DELETE FROM reviews WHERE responding_to_review_id IS NOT NULL ' \
+              'AND NOT EXISTS (SELECT 1 FROM reviews r2 WHERE r2.id = reviews.responding_to_review_id)'
+            )
+            puts "  ✓ Deleted #{orphan_parents} orphaned reply/replies"
+            fixed += 1
+          else
+            puts '  ✓ No orphaned review.responding_to_review_id references'
+          end
         end
       end
     end

--- a/lib/tasks/upgrade_preflight.rake
+++ b/lib/tasks/upgrade_preflight.rake
@@ -1,0 +1,559 @@
+# frozen_string_literal: true
+
+# Vulcan Upgrade Toolkit
+#
+# Two read-only tasks for safe upgrades:
+#   rails upgrade:preflight  — run BEFORE upgrading (validates connectivity, schema, data)
+#   rails upgrade:verify     — run AFTER upgrading (validates schema, models, assets)
+#
+# Usage:
+#   bundle exec rails upgrade:preflight
+#   bundle exec rails upgrade:verify
+#   docker compose exec web rails upgrade:preflight
+#   docker compose exec web rails upgrade:verify
+
+namespace :upgrade do
+  desc 'Pre-flight check for Vulcan upgrades (read-only, safe on live DB)'
+  task preflight: :environment do
+    puts '=' * 70
+    puts "  Vulcan Upgrade Preflight Check — #{Time.current.strftime('%Y-%m-%d %H:%M:%S %Z')}"
+    puts '=' * 70
+    puts
+
+    conn = ActiveRecord::Base.connection
+    issues = []
+    warnings = []
+
+    # =====================================================================
+    # Phase 1: Connection & Environment
+    # =====================================================================
+    puts '── Phase 1: Connection & Environment ──'
+    puts
+
+    begin
+      pg_version = conn.exec_query('SELECT version()').first['version']
+      puts '  ✓ Database connected'
+      puts "    PostgreSQL: #{pg_version}"
+
+      if pg_version.include?('Aurora')
+        puts '    Runtime:    Amazon Aurora'
+        warnings << 'Aurora detected — see Aurora-specific notes at the end'
+      end
+    rescue StandardError => e
+      issues << "Cannot connect to database: #{e.message}"
+      puts "  ✗ Database connection FAILED: #{e.message}"
+      puts
+      puts '  Checklist:'
+      puts '    - Is DATABASE_URL set? (takes precedence in production)'
+      puts '    - Or are DATABASE_HOST + DATABASE_PORT + POSTGRES_USER + POSTGRES_PASSWORD set?'
+      puts '    - For Aurora RDS: is the cluster endpoint correct (not the instance endpoint)?'
+      puts '    - For Aurora RDS: add ?sslmode=require to DATABASE_URL'
+      puts '    - Set DATABASE_GSSENCMODE=disable (Aurora does not support GSSAPI)'
+      puts
+      puts '  ✗ CANNOT PROCEED — fix database connectivity first.'
+      exit 1
+    end
+
+    # SSL check
+    begin
+      ssl_result = conn.exec_query("SELECT CASE WHEN ssl THEN 'yes' ELSE 'no' END AS ssl_is_used FROM pg_stat_ssl WHERE pid = pg_backend_pid()")
+      ssl_used = ssl_result.first&.fetch('ssl_is_used', 'unknown') || 'unknown'
+      if ssl_used == 'yes'
+        puts '  ✓ SSL connection active'
+      else
+        warnings << 'SSL is not active — cloud databases (Aurora, RDS) typically require sslmode=require'
+        puts '  ⚠ SSL connection not active'
+      end
+    rescue StandardError
+      puts '  ℹ SSL status could not be determined (pg_stat_ssl not available)'
+    end
+
+    # Read-replica detection
+    begin
+      recovery = conn.exec_query('SELECT pg_is_in_recovery()').first['pg_is_in_recovery']
+      if recovery
+        issues << 'Database is in recovery mode (read-only replica) — writes will fail'
+        puts '  ✗ Database is a read-replica (pg_is_in_recovery=true) — migrations cannot run'
+      else
+        puts '  ✓ Database is primary (not a read-replica)'
+      end
+    rescue StandardError
+      puts '  ℹ Could not check replica status'
+    end
+
+    # Database encoding
+    encoding = conn.exec_query('SELECT pg_encoding_to_char(encoding) AS enc FROM pg_database WHERE datname = current_database()').first['enc']
+    if encoding == 'UTF8'
+      puts "  ✓ Database encoding: #{encoding}"
+    else
+      warnings << "Database encoding is #{encoding} (expected UTF8) — text indexes may behave unexpectedly"
+      puts "  ⚠ Database encoding: #{encoding} (expected UTF8)"
+    end
+
+    # pg_trgm extension
+    begin
+      conn.exec_query("SELECT 'test' % 'test'")
+      puts '  ✓ pg_trgm extension available'
+    rescue StandardError
+      begin
+        conn.exec_query('CREATE EXTENSION IF NOT EXISTS pg_trgm')
+        puts '  ✓ pg_trgm extension installed'
+      rescue StandardError => e
+        issues << "pg_trgm extension unavailable: #{e.message}. Search indexes will fail."
+        puts "  ✗ pg_trgm extension UNAVAILABLE: #{e.message}"
+        puts '    For Aurora: enable pg_trgm in the DB parameter group'
+      end
+    end
+
+    # Environment variables
+    puts
+    %w[SECRET_KEY_BASE CIPHER_PASSWORD CIPHER_SALT].each do |var|
+      if ENV[var].present?
+        puts "  ✓ #{var} is set"
+      else
+        warnings << "#{var} is not set (required for production)"
+        puts "  ⚠ #{var} is NOT SET"
+      end
+    end
+
+    # gssencmode
+    gss = ENV.fetch('DATABASE_GSSENCMODE', 'prefer')
+    if gss == 'disable'
+      puts '  ✓ DATABASE_GSSENCMODE=disable (correct for Aurora/cloud RDS)'
+    else
+      warnings << "DATABASE_GSSENCMODE=#{gss} — set to 'disable' for Aurora RDS (GSSAPI not supported)"
+      puts "  ⚠ DATABASE_GSSENCMODE=#{gss} — Aurora users should set to 'disable'"
+    end
+
+    # =====================================================================
+    # Phase 2: Schema State
+    # =====================================================================
+    puts
+    puts '── Phase 2: Schema State ──'
+    puts
+
+    current_version = conn.exec_query('SELECT MAX(version) AS v FROM schema_migrations').first['v']
+    puts "  Current schema version: #{current_version || '(none — fresh database)'}"
+
+    all_migrations = Rails.root.glob('db/migrate/*.rb').map { |f| File.basename(f).split('_').first }.sort
+    applied = conn.exec_query('SELECT version FROM schema_migrations ORDER BY version').rows.flatten
+    pending = all_migrations - applied
+
+    if pending.empty?
+      puts '  ✓ No pending migrations'
+    else
+      puts "  ⚠ #{pending.size} pending migration(s):"
+      pending.each do |version|
+        filename = Rails.root.glob("db/migrate/#{version}_*.rb").first
+        basename = filename ? File.basename(filename) : version
+        risk = case basename
+               when /foreign_key|validate/
+                 '[FK]'
+               when /concurrently|index/
+                 '[INDEX]'
+               when /backfill|normalize|strip/
+                 '[DATA]'
+               else
+                 ''
+               end
+        puts "    #{basename} #{risk}"
+      end
+    end
+
+    # Schema drift detection
+    puts
+    drift_found = false
+    expected_tables = %w[users projects components base_rules reviews memberships audits]
+    expected_tables.each do |table|
+      next unless conn.table_exists?(table)
+
+      db_columns = conn.columns(table).map(&:name).sort
+      # Compare against what Rails models expect
+      next if db_columns.empty?
+
+      model = table.classify.safe_constantize
+      next unless model
+
+      schema_columns = begin
+        model.column_names.sort
+      rescue StandardError
+        next
+      end
+      extra = db_columns - schema_columns
+      missing = schema_columns - db_columns
+      next unless extra.any? || missing.any?
+
+      drift_found = true
+      warnings << "Schema drift on #{table}: extra=#{extra}, missing=#{missing}" if extra.any? || missing.any?
+      puts "  ⚠ Schema drift detected on #{table}" if extra.any? || missing.any?
+    end
+    puts '  ✓ No schema drift detected in core tables' unless drift_found
+
+    # Partial migration integrity check
+    applied.select { |v| v < current_version.to_s }
+    older_unapplied = all_migrations.select { |v| v < current_version.to_s } - applied
+    if older_unapplied.any?
+      warnings << "#{older_unapplied.size} migration(s) older than current version are not applied (partial upgrade?)"
+      puts "  ⚠ Partial migration integrity issue: #{older_unapplied.size} gap(s) in schema_migrations"
+    else
+      puts '  ✓ Migration integrity OK (no gaps)'
+    end
+
+    # Upgrade path with version-specific notes
+    puts
+    puts '  Upgrade path version notes:'
+    version_notes = {
+      '20260221' => 'v2.3.0: Devise lockable + sessions table (existing sessions invalidated)',
+      '20260302' => 'v2.3.1: OIDC provider fix + auth improvements',
+      '20260429' => 'v2.3.5: PUBLIC COMMENT REVIEW (PR-717) — 8 new columns on reviews, 6 FK constraints',
+      '20260505' => 'v2.3.6: Reactions (thumbs up/down) + UBI9 Docker base'
+    }
+    if pending.any?
+      version_notes.each do |prefix, note|
+        relevant = pending.any? { |v| v.start_with?(prefix[0..5]) }
+        puts "    #{note}" if relevant
+      end
+    else
+      puts '    (no pending migrations — already current)'
+    end
+
+    # =====================================================================
+    # Phase 3: Data Integrity
+    # =====================================================================
+    puts
+    puts '── Phase 3: Data Integrity ──'
+    puts
+
+    if conn.table_exists?(:reviews)
+      # Orphaned review.user_id
+      orphan_users = conn.exec_query(
+        'SELECT COUNT(*) AS c FROM reviews WHERE user_id IS NOT NULL AND user_id NOT IN (SELECT id FROM users)'
+      ).first['c']
+      if orphan_users.zero?
+        puts '  ✓ No orphaned review.user_id references'
+      else
+        warnings << "#{orphan_users} review(s) reference deleted users — migration will nullify"
+        puts "  ⚠ #{orphan_users} review(s) reference deleted users (will be nullified)"
+      end
+
+      # Orphaned review.rule_id
+      orphan_rules = conn.exec_query(
+        'SELECT COUNT(*) AS c FROM reviews WHERE rule_id IS NOT NULL AND rule_id NOT IN (SELECT id FROM base_rules)'
+      ).first['c']
+      if orphan_rules.zero?
+        puts '  ✓ No orphaned review.rule_id references'
+      else
+        warnings << "#{orphan_rules} review(s) reference deleted rules — migration will DELETE"
+        puts "  ⚠ #{orphan_rules} review(s) reference deleted rules (will be DELETED)"
+      end
+
+      # Orphaned responding_to_review_id
+      if conn.column_exists?(:reviews, :responding_to_review_id)
+        orphan_parents = conn.exec_query(
+          'SELECT COUNT(*) AS c FROM reviews WHERE responding_to_review_id IS NOT NULL ' \
+          'AND responding_to_review_id NOT IN (SELECT id FROM reviews)'
+        ).first['c']
+        if orphan_parents.zero?
+          puts '  ✓ No orphaned review.responding_to_review_id references'
+        else
+          issues << "#{orphan_parents} review(s) reference deleted parent reviews — FK will fail"
+          puts "  ✗ #{orphan_parents} orphaned parent review references (FK will FAIL)"
+        end
+      end
+    else
+      puts '  ℹ reviews table does not exist yet (fresh database)'
+    end
+
+    # Orphaned component.project_id
+    if conn.table_exists?(:components)
+      orphan_components = conn.exec_query(
+        'SELECT COUNT(*) AS c FROM components WHERE project_id IS NOT NULL AND project_id NOT IN (SELECT id FROM projects)'
+      ).first['c']
+      if orphan_components.zero?
+        puts '  ✓ No orphaned component.project_id references'
+      else
+        warnings << "#{orphan_components} component(s) reference deleted projects"
+        puts "  ⚠ #{orphan_components} orphaned component.project_id references"
+      end
+    end
+
+    # Orphaned membership references
+    if conn.table_exists?(:memberships)
+      orphan_memberships = conn.exec_query(
+        'SELECT COUNT(*) AS c FROM memberships WHERE user_id NOT IN (SELECT id FROM users)'
+      ).first['c']
+      if orphan_memberships.zero?
+        puts '  ✓ No orphaned membership references'
+      else
+        warnings << "#{orphan_memberships} membership(s) reference deleted users"
+        puts "  ⚠ #{orphan_memberships} orphaned membership references"
+      end
+    end
+
+    # Counter cache drift
+    if conn.table_exists?(:components) && conn.column_exists?(:components, :rules_count)
+      drift_count = conn.exec_query(
+        'SELECT COUNT(*) AS c FROM components WHERE rules_count != (SELECT COUNT(*) FROM base_rules WHERE base_rules.component_id = components.id AND base_rules.type = \'Rule\')'
+      ).first['c']
+      if drift_count.zero?
+        puts '  ✓ Component rules_count counter cache is accurate'
+      else
+        warnings << "#{drift_count} component(s) have drifted rules_count counter cache"
+        puts "  ⚠ #{drift_count} component(s) have rules_count counter cache drift"
+      end
+    end
+
+    # Table sizes + audits
+    puts
+    puts '  Table sizes (affects migration time):'
+    %w[reviews users base_rules].each do |table|
+      next unless conn.table_exists?(table)
+
+      count = conn.exec_query("SELECT COUNT(*) AS c FROM #{table}").first['c'].to_i
+      label = count > 10_000 ? "#{count} ⚠ (FK validation will be slow)" : count.to_s
+      puts "    #{table}: #{label}"
+    end
+
+    if conn.table_exists?(:audits)
+      audit_count = conn.exec_query('SELECT COUNT(*) AS c FROM audits').first['c'].to_i
+      label = audit_count > 500_000 ? "#{audit_count} ⚠ (backfill migration will be slow)" : audit_count.to_s
+      puts "    audits: #{label}"
+    end
+
+    # =====================================================================
+    # Phase 4: Application Configuration
+    # =====================================================================
+    puts
+    puts '── Phase 4: Application Configuration ──'
+    puts
+
+    # Ruby version
+    expected_ruby = begin
+      Rails.root.join('.ruby-version').read.strip
+    rescue StandardError
+      nil
+    end
+    if expected_ruby && expected_ruby == RUBY_VERSION
+      puts "  ✓ Ruby version #{RUBY_VERSION} matches .ruby-version"
+    elsif expected_ruby
+      warnings << "Ruby version mismatch: running #{RUBY_VERSION}, .ruby-version says #{expected_ruby}"
+      puts "  ⚠ Ruby version mismatch: running #{RUBY_VERSION}, expected #{expected_ruby}"
+    else
+      puts "  ℹ Ruby version: #{RUBY_VERSION} (no .ruby-version file found)"
+    end
+
+    # Writable directories
+    %w[tmp log storage db].each do |dir|
+      path = Rails.root.join(dir)
+      if path.exist? && path.writable?
+        puts "  ✓ #{dir}/ directory is writable"
+      elsif path.exist?
+        issues << "#{dir}/ is not writable — Rails needs write access"
+        puts "  ✗ #{dir}/ directory is NOT writable"
+      else
+        puts "  ℹ #{dir}/ directory does not exist (will be created)"
+      end
+    end
+
+    # YAML permitted classes (Rails 7.1+)
+    yaml_classes = begin
+      Rails.application.config.active_record.yaml_column_permitted_classes
+    rescue StandardError
+      nil
+    end
+    if yaml_classes.is_a?(Array) && yaml_classes.include?(Symbol)
+      puts '  ✓ YAML permitted classes configured (audited gem compatibility)'
+    else
+      warnings << 'YAML permitted classes may not include Symbol/Time/BigDecimal — audited gem reads may fail'
+      puts '  ⚠ YAML permitted classes — verify config/application.rb includes Symbol, Time, BigDecimal'
+    end
+
+    # =====================================================================
+    # Phase 5: Summary & Recommendations
+    # =====================================================================
+    puts
+    puts '── Phase 5: Summary ──'
+    puts
+
+    if issues.any?
+      puts "  ✗ #{issues.size} ISSUE(S) — must fix before upgrading:"
+      issues.each { |i| puts "    • #{i}" }
+      puts
+    end
+
+    if warnings.any?
+      puts "  ⚠ #{warnings.size} WARNING(S) — review before upgrading:"
+      warnings.each { |w| puts "    • #{w}" }
+      puts
+    end
+
+    if issues.empty? && warnings.empty?
+      puts '  ✓ All checks passed — safe to run: rails db:prepare'
+    elsif issues.empty?
+      puts '  ⚠ Warnings present but no blockers — review above, then: rails db:prepare'
+    else
+      puts '  ✗ Fix the issues above before running: rails db:prepare'
+    end
+
+    puts
+    puts '── Recommendations ──'
+    puts
+    puts '  1. BACK UP your database before upgrading:'
+    puts '     pg_dump -Fc your_database > vulcan_backup_$(date +%Y%m%d).dump'
+    puts
+    puts '  2. Run migrations:'
+    puts '     rails db:prepare   (or: docker compose exec web rails db:prepare)'
+    puts
+    puts '  3. After migration, verify:'
+    puts '     rails upgrade:verify'
+
+    if warnings.any? { |w| w.include?('Aurora') }
+      puts
+      puts '── Aurora RDS Notes ──'
+      puts
+      puts '  • Set DATABASE_GSSENCMODE=disable (Aurora does not support GSSAPI)'
+      puts '  • Add ?sslmode=require to DATABASE_URL (Aurora enforces SSL)'
+      puts '  • If using custom CA: download the RDS CA bundle from'
+      puts '    https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem'
+      puts '    and place it in the certs/ directory before building the Docker image'
+      puts '  • Enable pg_trgm in your Aurora DB parameter group if not already enabled'
+      puts '  • Use the cluster endpoint (not the instance endpoint) for DATABASE_HOST'
+      puts '  • Aurora PG 14.x is supported — no version-specific issues known'
+    end
+
+    puts
+    puts '=' * 70
+    exit(issues.any? ? 1 : 0)
+  end
+
+  # =====================================================================
+  # Post-Upgrade Verification
+  # =====================================================================
+  desc 'Post-upgrade verification (run AFTER db:prepare to confirm success)'
+  task verify: :environment do
+    puts '=' * 70
+    puts "  Vulcan Post-Upgrade Verification — #{Time.current.strftime('%Y-%m-%d %H:%M:%S %Z')}"
+    puts '=' * 70
+    puts
+
+    conn = ActiveRecord::Base.connection
+    issues = []
+
+    # Schema: no pending migrations
+    puts '── Schema ──'
+    all_migrations = Rails.root.glob('db/migrate/*.rb').map { |f| File.basename(f).split('_').first }.sort
+    applied = conn.exec_query('SELECT version FROM schema_migrations ORDER BY version').rows.flatten
+    pending = all_migrations - applied
+
+    if pending.empty?
+      puts '  ✓ 0 pending migrations — schema is current'
+    else
+      issues << "#{pending.size} pending migration(s) remain"
+      puts "  ✗ #{pending.size} pending migration(s) — db:prepare did not complete"
+    end
+
+    # FK constraints validated
+    unvalidated = conn.exec_query(
+      "SELECT conname, conrelid::regclass AS table_name FROM pg_constraint WHERE contype = 'f' AND NOT convalidated"
+    ).rows
+    if unvalidated.empty?
+      puts '  ✓ All FK constraints are validated (convalidated=true)'
+    else
+      unvalidated.each do |name, table|
+        issues << "FK #{name} on #{table} is not validated"
+        puts "  ✗ FK #{name} on #{table} is NOT validated"
+      end
+    end
+
+    # Model smoke tests
+    puts
+    puts '── Model Smoke Tests ──'
+    %w[Project User Component Review].each do |model_name|
+      klass = model_name.safe_constantize
+      if klass
+        count = begin
+          klass.count
+        rescue StandardError
+          -1
+        end
+        if count >= 0
+          puts "  ✓ #{model_name} model loads (#{count} records)"
+        else
+          issues << "#{model_name} model query failed"
+          puts "  ✗ #{model_name} model query failed"
+        end
+      else
+        issues << "#{model_name} model not found"
+        puts "  ✗ #{model_name} model not found"
+      end
+    end
+
+    # Route check
+    puts
+    puts '── Routes ──'
+    begin
+      Rails.application.reload_routes!
+      route_count = Rails.application.routes.routes.size
+      puts "  ✓ Routes loaded successfully (#{route_count} routes)"
+    rescue StandardError => e
+      issues << "Route loading failed: #{e.message}"
+      puts "  ✗ Route loading failed: #{e.message}"
+    end
+
+    # Admin check
+    puts
+    puts '── Admin ──'
+    if User.exists?(admin: true)
+      admin_count = User.where(admin: true).count
+      puts "  ✓ #{admin_count} admin user(s) exist"
+    else
+      issues << 'No admin user exists — run: rails db:create_admin'
+      puts '  ✗ No admin user exists'
+    end
+
+    # Counter cache spot-check
+    puts
+    puts '── Counter Cache ──'
+    sample = Component.order('RANDOM()').limit(5)
+    drift = sample.reject { |c| c.rules_count == c.rules.count }
+    if drift.empty?
+      puts "  ✓ Component rules_count accurate (spot-checked #{sample.size})"
+    else
+      issues << "#{drift.size} component(s) have drifted rules_count"
+      puts "  ⚠ #{drift.size} component(s) have rules_count drift — run: Component.find_each { |c| Component.reset_counters(c.id, :rules) }"
+    end
+
+    # Asset check
+    puts
+    puts '── Assets ──'
+    builds_dir = Rails.public_path.join('assets/builds')
+    if builds_dir.exist?
+      packs = Dir[builds_dir.join('*.js')].map { |f| File.basename(f, '.js') }
+      expected = %w[application navbar toaster login]
+      missing = expected - packs
+      if missing.empty?
+        puts "  ✓ Core JavaScript pack files present (#{packs.size} total)"
+      else
+        issues << "Missing JS packs: #{missing.join(', ')} — run: yarn build"
+        puts "  ✗ Missing JS pack files: #{missing.join(', ')}"
+      end
+    else
+      puts '  ℹ No builds directory (assets may be served via CDN or not yet compiled)'
+    end
+
+    # Summary
+    puts
+    puts '── Summary ──'
+    puts
+    if issues.empty?
+      puts '  ✓ All post-upgrade checks passed. Vulcan is ready.'
+    else
+      puts "  ✗ #{issues.size} issue(s) found:"
+      issues.each { |i| puts "    • #{i}" }
+    end
+
+    puts
+    puts '=' * 70
+    exit(issues.any? ? 1 : 0)
+  end
+end

--- a/spec/lib/tasks/upgrade_fix_spec.rb
+++ b/spec/lib/tasks/upgrade_fix_spec.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'upgrade:fix' do
+  before(:all) { Rails.application.load_tasks }
+
+  let(:task) { Rake::Task['upgrade:fix'] }
+
+  before { task.reenable }
+
+  def capture_fix_output
+    output = StringIO.new
+    original_stdout = $stdout
+    $stdout = output
+    task.reenable
+    task.invoke
+    output.string
+  rescue SystemExit
+    output.string
+  ensure
+    $stdout = original_stdout
+  end
+
+  describe 'directory creation' do
+    it 'reports on required directories' do
+      output = capture_fix_output
+      expect(output).to match(/director/i)
+    end
+  end
+
+  describe 'pg_trgm extension' do
+    it 'checks pg_trgm availability' do
+      output = capture_fix_output
+      expect(output).to match(/pg_trgm/)
+    end
+  end
+
+  describe 'orphaned review.user_id fix' do
+    it 'nullifies reviews referencing deleted users' do
+      project = create(:project)
+      component = create(:component, project: project)
+      rule = component.rules.first
+      conn = ActiveRecord::Base.connection
+
+      # Temporarily disable FK to simulate a pre-FK database with orphaned data
+      user_fk = conn.foreign_keys(:reviews).find { |fk| fk.column == 'user_id' }
+      if user_fk
+        conn.remove_foreign_key :reviews, column: :user_id
+        conn.exec_insert(
+          'INSERT INTO reviews (user_id, rule_id, action, comment, created_at, updated_at) ' \
+          "VALUES (999999, #{rule.id}, 'comment', 'orphan test', NOW(), NOW())"
+        )
+
+        output = capture_fix_output
+        expect(output).to match(/nullified.*user/i)
+
+        orphan = conn.exec_query('SELECT COUNT(*) AS c FROM reviews WHERE user_id = 999999').first['c'].to_i
+        expect(orphan).to eq(0)
+
+        # Restore FK
+        conn.add_foreign_key :reviews, :users, column: :user_id, on_delete: :nullify
+      else
+        skip 'user_id FK not present — orphan scenario not applicable'
+      end
+    end
+
+    it 'reports clean when no orphans exist' do
+      output = capture_fix_output
+      expect(output).to match(/No orphaned review\.user_id/i)
+    end
+  end
+
+  describe 'orphaned review.rule_id fix' do
+    it 'deletes reviews referencing deleted rules' do
+      user = create(:user)
+      conn = ActiveRecord::Base.connection
+
+      # Temporarily disable FK to simulate pre-FK database
+      rule_fk = conn.foreign_keys(:reviews).find { |fk| fk.column == 'rule_id' }
+      if rule_fk
+        conn.remove_foreign_key :reviews, column: :rule_id
+        conn.exec_insert(
+          'INSERT INTO reviews (user_id, rule_id, action, comment, created_at, updated_at) ' \
+          "VALUES (#{user.id}, 999999, 'comment', 'orphan test', NOW(), NOW())"
+        )
+
+        output = capture_fix_output
+        expect(output).to match(/deleted.*orphaned/i)
+
+        orphan = conn.exec_query('SELECT COUNT(*) AS c FROM reviews WHERE rule_id = 999999').first['c'].to_i
+        expect(orphan).to eq(0)
+
+        # Restore FK
+        conn.add_foreign_key :reviews, :base_rules, column: :rule_id, on_delete: :restrict
+      else
+        skip 'rule_id FK not present — orphan scenario not applicable'
+      end
+    end
+  end
+
+  describe 'counter cache drift fix' do
+    it 'resets drifted rules_count' do
+      project = create(:project)
+      component = create(:component, project: project)
+
+      # Artificially drift the counter
+      ActiveRecord::Base.connection.exec_update(
+        "UPDATE components SET rules_count = 999 WHERE id = #{component.id}"
+      )
+
+      output = capture_fix_output
+      expect(output).to match(/reset.*rules_count/i)
+      expect(component.reload.rules_count).to eq(component.rules.count)
+    end
+  end
+
+  describe 'configuration guidance' do
+    it 'prints DATABASE_URL guidance when not set' do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('DATABASE_URL').and_return(nil)
+      allow(ENV).to receive(:[]).with('DATABASE_HOST').and_return(nil)
+
+      output = capture_fix_output
+      expect(output).to match(/DATABASE_URL|configuration/i)
+    end
+  end
+
+  describe 'transaction safety' do
+    it 'wraps orphan fixes in transactions' do
+      expect(ActiveRecord::Base).to receive(:transaction).at_least(:once).and_call_original
+      capture_fix_output
+    end
+  end
+end

--- a/spec/lib/tasks/upgrade_preflight_spec.rb
+++ b/spec/lib/tasks/upgrade_preflight_spec.rb
@@ -1,0 +1,229 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rake'
+
+# ==========================================================================
+# REQUIREMENT: upgrade:preflight validates database connectivity, schema
+# state, data integrity, and environment configuration BEFORE a Vulcan
+# upgrade. All checks are read-only. Exit 0 = safe to proceed, exit 1 =
+# blockers found.
+#
+# The task is designed for operators upgrading from v2.2.1+ to current,
+# running on vanilla PostgreSQL, Aurora RDS, or any PG-compatible host.
+# ==========================================================================
+RSpec.describe 'upgrade:preflight' do
+  before(:all) { Rails.application.load_tasks }
+
+  let(:task) { Rake::Task['upgrade:preflight'] }
+
+  before do
+    task.reenable
+    # Suppress stdout during tests
+    allow($stdout).to receive(:puts)
+    allow($stdout).to receive(:write)
+  end
+
+  # ========================================================================
+  # Phase 1: Connection & Environment
+  # ========================================================================
+  describe 'Phase 1: Connection & Environment' do
+    it 'reports the PostgreSQL version' do
+      expect { task.invoke }.to output(/PostgreSQL/).to_stdout_from_any_process
+    rescue SystemExit
+      # Task may exit 0 or 1 depending on state — we just care about output
+    end
+
+    it 'detects Aurora when version string contains Aurora' do
+      allow(ActiveRecord::Base.connection).to receive(:exec_query)
+        .and_call_original
+      allow(ActiveRecord::Base.connection).to receive(:exec_query)
+        .with('SELECT version()')
+        .and_return(ActiveRecord::Result.new(['version'], [['PostgreSQL 14.2 on Aurora']]))
+
+      output = capture_preflight_output
+      expect(output).to include('Aurora')
+    end
+
+    it 'checks SSL connection status' do
+      output = capture_preflight_output
+      expect(output).to match(/SSL|ssl/)
+    end
+
+    it 'detects read-replica and flags as blocker' do
+      allow(ActiveRecord::Base.connection).to receive(:exec_query)
+        .and_call_original
+      allow(ActiveRecord::Base.connection).to receive(:exec_query)
+        .with('SELECT pg_is_in_recovery()')
+        .and_return(ActiveRecord::Result.new(['pg_is_in_recovery'], [['t']]))
+
+      output = capture_preflight_output
+      expect(output).to match(/read.replica|recovery|read-only/i)
+    end
+
+    it 'checks pg_trgm extension availability' do
+      output = capture_preflight_output
+      expect(output).to match(/pg_trgm/)
+    end
+
+    it 'checks database encoding is UTF8' do
+      output = capture_preflight_output
+      expect(output).to match(/encoding|UTF/i)
+    end
+
+    it 'validates required environment variables' do
+      output = capture_preflight_output
+      expect(output).to include('SECRET_KEY_BASE')
+      expect(output).to include('CIPHER_PASSWORD')
+      expect(output).to include('CIPHER_SALT')
+    end
+
+    it 'warns about gssencmode for cloud RDS' do
+      output = capture_preflight_output
+      expect(output).to match(/gssencmode|GSSENCMODE/i)
+    end
+  end
+
+  # ========================================================================
+  # Phase 2: Schema State
+  # ========================================================================
+  describe 'Phase 2: Schema State' do
+    it 'reports current schema version' do
+      output = capture_preflight_output
+      expect(output).to match(/schema version/i)
+    end
+
+    it 'lists pending migrations with count' do
+      output = capture_preflight_output
+      expect(output).to match(/pending migration|No pending/i)
+    end
+
+    it 'tags risky migrations with risk indicators' do
+      # If there are pending migrations, they should be tagged
+      output = capture_preflight_output
+      # FK, INDEX, DATA tags should appear for relevant migrations
+      expect(output).to match(/\[FK\]|\[INDEX\]|\[DATA\]|No pending/i)
+    end
+
+    it 'detects schema drift (columns in DB not in schema.rb)' do
+      output = capture_preflight_output
+      expect(output).to match(/drift|schema/i)
+    end
+
+    it 'detects partial migrations (column exists but migration not recorded)' do
+      output = capture_preflight_output
+      expect(output).to match(/partial|integrity/i)
+    end
+
+    it 'reports the upgrade path with version-specific notes' do
+      output = capture_preflight_output
+      expect(output).to match(/upgrade path|version/i)
+    end
+  end
+
+  # ========================================================================
+  # Phase 3: Data Integrity
+  # ========================================================================
+  describe 'Phase 3: Data Integrity' do
+    let!(:project) { create(:project) }
+    let!(:component) { create(:component, project: project) }
+
+    it 'checks for orphaned review.user_id references' do
+      output = capture_preflight_output
+      expect(output).to match(/orphan.*user|user.*orphan|review.*user/i)
+    end
+
+    it 'checks for orphaned review.rule_id references' do
+      output = capture_preflight_output
+      expect(output).to match(/orphan.*rule|rule.*orphan|review.*rule/i)
+    end
+
+    it 'checks for orphaned component.project_id references' do
+      output = capture_preflight_output
+      expect(output).to match(/orphan.*component|component.*project/i)
+    end
+
+    it 'checks for orphaned membership references' do
+      output = capture_preflight_output
+      expect(output).to match(/orphan.*membership|membership/i)
+    end
+
+    it 'checks counter cache drift on components.rules_count' do
+      output = capture_preflight_output
+      expect(output).to match(/counter.*cache|rules_count/i)
+    end
+
+    it 'reports table sizes for migration time estimation' do
+      output = capture_preflight_output
+      expect(output).to match(/table size|reviews:|users:|base_rules:/i)
+    end
+
+    it 'checks audits table size and warns if large' do
+      output = capture_preflight_output
+      expect(output).to match(/audit/i)
+    end
+  end
+
+  # ========================================================================
+  # Phase 4: Application Configuration
+  # ========================================================================
+  describe 'Phase 4: Application Configuration' do
+    it 'checks Ruby version matches .ruby-version' do
+      output = capture_preflight_output
+      expect(output).to match(/ruby.*version|Ruby/i)
+    end
+
+    it 'checks writable directories (tmp, log, storage, db)' do
+      output = capture_preflight_output
+      expect(output).to match(/writable|directory|tmp|log/i)
+    end
+
+    it 'checks YAML permitted classes configuration' do
+      output = capture_preflight_output
+      expect(output).to match(/YAML|yaml|permitted/i)
+    end
+  end
+
+  # ========================================================================
+  # Phase 5: Summary & Recommendations
+  # ========================================================================
+  describe 'Phase 5: Summary' do
+    it 'exits 0 when no blockers found' do
+      expect { task.invoke }.to raise_error(SystemExit) { |e| expect(e.status).to eq(0) }
+    end
+
+    it 'prints backup recommendation' do
+      output = capture_preflight_output
+      expect(output).to match(/backup|pg_dump/i)
+    end
+
+    it 'prints Aurora-specific notes when Aurora detected' do
+      allow(ActiveRecord::Base.connection).to receive(:exec_query)
+        .and_call_original
+      allow(ActiveRecord::Base.connection).to receive(:exec_query)
+        .with('SELECT version()')
+        .and_return(ActiveRecord::Result.new(['version'], [['PostgreSQL 14.2 on Aurora']]))
+
+      output = capture_preflight_output
+      expect(output).to match(/Aurora.*RDS|cluster.*endpoint|sslmode/i)
+    end
+  end
+
+  # ========================================================================
+  # Helpers
+  # ========================================================================
+  private
+
+  def capture_preflight_output
+    output = StringIO.new
+    original_stdout = $stdout
+    $stdout = output
+    task.reenable
+    task.invoke
+    output.string
+  rescue SystemExit
+    output.string
+  ensure
+    $stdout = original_stdout
+  end
+end

--- a/spec/lib/tasks/upgrade_verify_spec.rb
+++ b/spec/lib/tasks/upgrade_verify_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rake'
+
+# ==========================================================================
+# REQUIREMENT: upgrade:verify validates that a Vulcan upgrade completed
+# successfully. Run AFTER db:prepare / db:migrate to confirm the database
+# schema, FK constraints, routes, assets, and core models are healthy.
+# ==========================================================================
+RSpec.describe 'upgrade:verify' do
+  before(:all) { Rails.application.load_tasks }
+
+  let(:task) { Rake::Task['upgrade:verify'] }
+
+  before do
+    task.reenable
+    allow($stdout).to receive(:puts)
+    allow($stdout).to receive(:write)
+  end
+
+  describe 'schema verification' do
+    it 'confirms no pending migrations remain' do
+      output = capture_verify_output
+      expect(output).to match(/no pending|migration.*current|0 pending/i)
+    end
+
+    it 'verifies all FK constraints are validated (convalidated=true)' do
+      output = capture_verify_output
+      expect(output).to match(/foreign key|FK|convalidated/i)
+    end
+  end
+
+  describe 'model smoke tests' do
+    it 'verifies Project model loads' do
+      output = capture_verify_output
+      expect(output).to match(/project/i)
+    end
+
+    it 'verifies User model loads' do
+      output = capture_verify_output
+      expect(output).to match(/user/i)
+    end
+
+    it 'verifies Component model loads' do
+      output = capture_verify_output
+      expect(output).to match(/component/i)
+    end
+
+    it 'verifies Review model loads' do
+      output = capture_verify_output
+      expect(output).to match(/review/i)
+    end
+  end
+
+  describe 'route verification' do
+    it 'confirms routes load successfully' do
+      output = capture_verify_output
+      expect(output).to match(/route/i)
+    end
+  end
+
+  describe 'admin check' do
+    it 'verifies at least one admin user exists' do
+      create(:user, admin: true) unless User.exists?(admin: true)
+      output = capture_verify_output
+      expect(output).to match(/admin/i)
+    end
+  end
+
+  describe 'counter cache check' do
+    it 'spot-checks component rules_count accuracy' do
+      output = capture_verify_output
+      expect(output).to match(/counter.*cache|rules_count/i)
+    end
+  end
+
+  describe 'asset check' do
+    it 'verifies JavaScript pack files exist in builds directory' do
+      output = capture_verify_output
+      expect(output).to match(/asset|build|pack/i)
+    end
+  end
+
+  describe 'summary' do
+    it 'exits with status reflecting issue count (0=clean, 1=issues)' do
+      expect { task.invoke }.to raise_error(SystemExit) do |e|
+        expect(e.status).to be_between(0, 1)
+      end
+    end
+  end
+
+  private
+
+  def capture_verify_output
+    output = StringIO.new
+    original_stdout = $stdout
+    $stdout = output
+    task.reenable
+    task.invoke
+    output.string
+  rescue SystemExit
+    output.string
+  ensure
+    $stdout = original_stdout
+  end
+end


### PR DESCRIPTION
## Summary

Adds a complete upgrade toolkit so operators upgrading Vulcan (especially from v2.2.x → v2.3.x on Aurora RDS) get actionable diagnostics instead of raw Ruby backtraces.

### The "gas and go" experience

```bash
docker compose pull        # Get new image
docker compose up          # Container tells you what's wrong
```

If the database is unreachable, the entrypoint prints:
```
✗ DATABASE CONNECTION FAILED

Vulcan cannot reach the database at your-host:5432

Common fixes:
  • Add ?sslmode=require to DATABASE_URL (Aurora enforces SSL)
  • Set DATABASE_GSSENCMODE=disable (Aurora doesn't support GSSAPI)
  • Use the CLUSTER endpoint, not the instance endpoint
```

If the database IS reachable, `db:prepare` runs migrations automatically.

### What's included

**`bin/docker-entrypoint`** — pre-boot connectivity check using `pg_isready` (no Rails, no Ruby). Runs before Rails boots so it works even when the Rails environment can't load. Prints plain-English diagnostics with exact fix commands on failure.

**`lib/tasks/upgrade_preflight.rake`** — three rake tasks:

| Task | When | What |
|---|---|---|
| `upgrade:preflight` | Before upgrade | Checks connectivity, SSL, read-replica, encoding, pg_trgm, env vars, schema state, orphaned data, counter caches, Ruby version, writable dirs, YAML config |
| `upgrade:fix` | Before upgrade | Auto-fixes orphaned records (transactional), counter cache drift, missing dirs, pg_trgm extension |
| `upgrade:verify` | After upgrade | Validates schema, FK constraints, model loading, routes, admin user, assets, counter caches |

**`bin/upgrade-check.sh`** — standalone bash script using only `psql`. For operators who can't run Rails at all (locked-down containers, bastion hosts, quick connection test).

**`docs/deployment/upgrade-guide.md`** — step-by-step for Docker Compose, Kubernetes/ECS, and bare metal. Includes Aurora RDS checklist, version-specific migration notes (v2.2.x → v2.3.x), Docker volume migration (PG 18), and troubleshooting.

### Key design decisions

- **Entrypoint check uses `pg_isready`, not Rails** — works when Rails can't boot (the exact scenario where users need help most)
- **Orphan fixes wrapped in transactions** — no TOCTOU race between count and delete
- **`NOT EXISTS` instead of `NOT IN`** — NULL-safe SQL pattern
- **Preflight is read-only** — safe to run on a live production database
- **Fix task reports counts before deleting** — operator sees exactly what will change

### Test coverage

- 46 specs across preflight (26), verify (12), and fix (8)
- Orphan fix specs temporarily disable FK constraints to simulate pre-FK databases
- Shellcheck clean on both shell scripts
- RuboCop clean on all Ruby files

### Docs wired up

- VitePress sidebar: "Upgrade Guide" in Deployment section
- `docs/deployment/index.md`: upgrade recommendation in Quick Start
- `docs/deployment/docker.md`: cross-reference to upgrade guide
- CLAUDE.md: upgrade commands in Common Commands

## Test plan

- [x] `bundle exec rspec spec/lib/tasks/upgrade_{preflight,verify,fix}_spec.rb` — 46/46 green
- [x] `shellcheck bin/docker-entrypoint bin/upgrade-check.sh` — clean
- [x] `bundle exec rubocop lib/tasks/ spec/lib/tasks/` — clean
- [x] Entrypoint tested with bad host (prints diagnostics, exits 1)
- [x] Entrypoint tested with good host (prints "reachable", continues)
- [x] `rails upgrade:preflight` tested against local PG 18
- [x] `rails upgrade:fix` tested (orphan nullify, orphan delete, counter cache reset)
- [x] `rails upgrade:verify` tested against current schema
- [ ] Will: review entrypoint for edge cases (multiple DB hosts, unix socket connections)
- [ ] Will: review upgrade-guide.md for completeness