### PR TITLE
chore(deps): upgrade Bundler to 4.0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bundler upgraded from 2.7.2 to 4.0.13 (`Gemfile.lock` `BUNDLED WITH`). The Dockerfile's `ARG BUNDLER_VERSION` pin and explicit `gem install bundler` step are removed: RubyGems and Bundler now release in lockstep, so the existing `gem update --system` in the build stage already provides the latest Bundler as RubyGems' default. `bundle install` uses it directly — no separate Bundler pin to maintain.
+
 ## [v2.3.7] - 2026-05-10
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,6 @@
 ARG RUBY_VERSION=3.4.9
 # Upstream SHA256 from https://www.ruby-lang.org/en/news/<release>/
 ARG RUBY_SHA256=7bb4d4f5e807cc27251d14d9d6086d182c5b25875191e44ab15b709cd7a7dd9c
-ARG BUNDLER_VERSION=2.7.2
 ARG NODE_VERSION=24.14.0
 
 # =============================================================================
@@ -84,7 +83,6 @@ FROM base AS build-base
 
 ARG RUBY_VERSION
 ARG RUBY_SHA256
-ARG BUNDLER_VERSION
 
 USER 0
 
@@ -125,13 +123,14 @@ RUN curl -fsSL https://cache.ruby-lang.org/pub/ruby/${RUBY_VERSION%.*}/ruby-${RU
     make -j"$(nproc)" && \
     make install && \
     gem update --system --no-document && \
-    gem install bundler:${BUNDLER_VERSION} --no-document && \
     chown -R 1000:0 /usr/local/bundle && \
     chmod -R g=u /usr/local/bundle && \
     cd /tmp && \
     rm -rf /tmp/ruby-${RUBY_VERSION} /tmp/ruby.tar.gz && \
     ruby --version && \
     bundle --version
+# `gem update --system` above upgrades RubyGems and its bundled Bundler in
+# lockstep (they share a release), so Bundler needs no separate install/pin.
 
 # jemalloc — UBI doesn't ship it; compile from source for ~20-30% memory savings.
 ARG JEMALLOC_VERSION=5.3.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -802,7 +802,7 @@ DEPENDENCIES
   with_advisory_lock (~> 5.1)
 
 RUBY VERSION
-   ruby 3.4.9p82
+  ruby 3.4.9p82
 
 BUNDLED WITH
-   2.7.2
+  4.0.13


### PR DESCRIPTION
Bump Gemfile.lock BUNDLED WITH from 2.7.2 to 4.0.13 and remove the Dockerfile's bundler management. RubyGems and Bundler now release in lockstep, so the `gem update --system` already in the build stage provides Bundler 4.0.13 as the RubyGems default -- the ARG BUNDLER_VERSION pin and gem install bundler steps are redundant. bundle install uses the default directly in every stage.

Going forward, we should be able to just inherit the base image's bundler and we can stop having to do so much manual fiddling with it in both the GH and IB builds.