### PR TITLE
Fix/staging UI polish

### DIFF
--- a/app/javascript/application.scss
+++ b/app/javascript/application.scss
@@ -650,6 +650,21 @@
     color: var(--vulcan-body-color);
   }
 
+  // Disabled state (e.g. the source-SRG picker before a kind is chosen).
+  // vue-multiselect's own CSS hardcodes #ededed on the control and its arrow,
+  // which reads as an unstyled light-gray box in dark mode; theme it so the
+  // disabled control matches the rest of the form. The default opacity stays,
+  // so it still reads as disabled.
+  .multiselect--disabled {
+    background: var(--vulcan-component-bg);
+  }
+
+  .multiselect--disabled .multiselect__current,
+  .multiselect--disabled .multiselect__select {
+    background: var(--vulcan-component-bg);
+    color: var(--vulcan-text-muted);
+  }
+
   // ── fad.4: Navbar, sidebar, breadcrumbs, tabs ────────────────────
   .breadcrumb {
     background-color: var(--vulcan-component-bg-alt);

--- a/app/javascript/components/components/NewComponentModal.vue
+++ b/app/javascript/components/components/NewComponentModal.vue
@@ -528,16 +528,13 @@ export default {
       }
 
       // Modal closes naturally (no preventDefault) — show background progress
-      this.$bvToast.toast(
-        "Creating component — copying the source SRG may take a moment for large SRGs...",
-        {
-          title: "Creating Component",
-          variant: "info",
-          solid: true,
-          noAutoHide: true,
-          id: "create-component-progress",
-        },
-      );
+      this.$bvToast.toast("Creating component — this may take a moment...", {
+        title: "Creating Component",
+        variant: "info",
+        solid: true,
+        noAutoHide: true,
+        id: "create-component-progress",
+      });
 
       let formData = new FormData();
       formData.append(

--- a/spec/javascript/components/components/NewComponentModal.spec.js
+++ b/spec/javascript/components/components/NewComponentModal.spec.js
@@ -106,13 +106,12 @@ describe("NewComponentModal", () => {
 
   // ==========================================
   // CREATION PROGRESS TOAST
-  // Requirement: every component is created FROM a source SRG, and the delay
-  // scales with that source's requirement count. The progress toast must not
-  // read as if the created component itself were an SRG (a STIG author seeing
-  // "large SRGs" reasonably read it as a mislabel) — it names the source copy.
+  // Requirement: the progress toast is kind-neutral. A STIG author seeing
+  // "large SRGs" read it as a mislabel, so the toast names neither SRG nor
+  // STIG — it only signals that creation may take a moment.
   // ==========================================
   describe("creation progress toast", () => {
-    it("describes the source SRG copy, not the created component's kind", async () => {
+    it("is kind-neutral — names neither SRG nor STIG", async () => {
       wrapper = shallowMount(NewComponentModal, {
         localVue,
         propsData: { ...defaultProps },
@@ -135,10 +134,10 @@ describe("NewComponentModal", () => {
       const progress = toastSpy.mock.calls.find(([msg]) => /creating component/i.test(msg));
       expect(progress).toBeTruthy();
       const [message] = progress;
-      // Names the source SRG being copied, and never claims the OUTPUT is an SRG
-      // or a STIG.
-      expect(message).toMatch(/source SRG/i);
-      expect(message).not.toMatch(/large STIGs/i);
+      // Kind-neutral: mentions neither SRG nor STIG, so creating a STIG never
+      // shows a mismatched "SRG".
+      expect(message).not.toMatch(/\bSRGs?\b/i);
+      expect(message).not.toMatch(/\bSTIGs?\b/i);
     });
   });
 


### PR DESCRIPTION
More simple cleanup on staging.

- [x] fix dropdown in component creation modal not using CSS until user hits a radio button
- [x] fix creation progress toast messages always referring to "SRG" even if the user was creating a STIG 