### PR TITLE
docs: publish v2.4.1 release notes and update latest-release pointers

### DIFF
--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -90,10 +90,10 @@ setup and first steps.
 ## Latest Release
 
 ::: info Current Version
-**v2.3.7** - Released May 2026
+**v2.4.1** - Released August 2026
 
-Component-level comments via polymorphic reviews, project-aggregate disposition matrix CSV export, "Comment" toolbar button rename, replies allowed on active threads after a comment period closes.
-[View Release Notes →](/release-notes/v2.3.7)
+Redesigned three-column comment-triage split-pane with a click-to-filter progress bar, accessibility improvements, SRG-authoring foundations, login-path security hardening (JSON login lockout + throttling), and a broad set of fixes.
+[View Release Notes →](/release-notes/v2.4.1)
 :::
 
 ## Why Vulcan?

--- a/docs/site/release-notes/index.md
+++ b/docs/site/release-notes/index.md
@@ -4,10 +4,11 @@ All Vulcan releases with changelogs and migration notes.
 
 ## Current Release
 
-- **[v2.3.7](v2.3.7)** — Component-level comments via polymorphic reviews, project-aggregate disposition matrix CSV export, "Comment" toolbar rename, replies allowed on active threads after the comment period closes, vocabulary refresh ("Overall Requirement" replaces "(general)").
+- **[v2.4.1](v2.4.1)** — Redesigned three-column comment-triage split-pane with a click-to-filter progress bar and accessibility landmarks, SRG-authoring foundations (persisted minted-identifier sequence), login-path security hardening (JSON login lockout + throttling, server-side local-login guard), and a broad set of fixes. **Self-hosted: the 2.4 line standardizes database names (`DB_SUFFIX` → `DATABASE_NAME`) — read the upgrade notes.**
 
 ## Previous Releases
 
+- **[v2.3.7](v2.3.7)** — Component-level comments via polymorphic reviews, project-aggregate disposition matrix CSV export, "Comment" toolbar rename, replies allowed on active threads after the comment period closes, vocabulary refresh ("Overall Requirement" replaces "(general)").
 - **[v2.3.6](v2.3.6)** — UBI9 base image (Iron Bank / DISA-aligned), public-comment-review workflow with triage + adjudication, viewer-can-comment, comment reactions (👍/👎), structured 403s with admin contacts. **Includes breaking Docker / Compose volume changes — read the release notes before upgrading.**
 - **[v2.3.5](v2.3.5)** — Server-side user search (information disclosure fix), editor refresh shape drift fix, CI/release workflow split
 - **[v2.3.4](v2.3.4)** — Blueprinter JSON serialization, query performance hardening, OIDC fix, auth UX

--- a/docs/site/release-notes/v2.4.1.md
+++ b/docs/site/release-notes/v2.4.1.md
@@ -1,0 +1,32 @@
+# Vulcan v2.4.1
+
+Released: 2026-08-26
+
+A feature release centered on a redesigned comment-triage experience and the foundations for SRG authoring, plus security hardening on the login paths and a broad set of fixes. See the [CHANGELOG](https://github.com/mitre/vulcan/blob/master/CHANGELOG.md) for the complete list.
+
+## Highlights
+
+- **Three-column triage split-pane** — triagers now work in a persistent layout: a rule sidebar (grouped, with pending/total counts, search, and keyboard navigation), the rule content, and the comment + triage form side by side, replacing the prev/next-plus-modal workflow. A **triage progress bar** above the table shows per-status counts with an "N of M resolved (X%)" summary and doubles as a click-to-filter control.
+- **Accessibility** — the split-pane uses proper `nav` / `main` / `complementary` landmarks, skip links, content-first focus management on entry and after Save & Next, and a single-Tab-stop composite sidebar. Status color dots on the filter toggles all meet 3:1 contrast in light and dark mode.
+- **SRG-authoring foundations** — a persisted minted-identifier sequence makes authored-derivation requirement IDs immune to SRG rebases and abbreviation changes (never-renumber on re-release), plus SRG-viewer and source-picker refinements.
+- **Quality-of-life** — a by-rule accordion view, 2D queue navigation, a "section updated since this comment" staleness badge, inline admin actions (force-withdraw, restore, move-to-rule, hard-delete with typed-ID confirmation), and shared InfoTooltip / InfoNotice components.
+
+## Security
+
+- **Login lockout and rate limiting on the JSON login path** — `/api/auth/login` previously did a bare password check, bypassing Devise account lockout (STIG AC-07) and all login throttling. It now runs the full Devise checks, returns a distinct `account_locked` 401, and both login paths share IP- and email-keyed throttles.
+- **Local-login toggle enforced server-side** — disabling local login previously only hid the form; a crafted POST could still authenticate with local credentials on an SSO-only instance. A shared guard now rejects both paths server-side.
+
+## Notable fixes
+
+- **Triage queue loads every comment past the server page cap** — the queue silently dropped comments beyond the 100-per-page limit; it now pages until the full total is loaded.
+- **Comment moves carry the entire reply subtree** — replies-to-replies at any depth now survive a comment's move between containers.
+- **Archive import preserves review edit timestamps** instead of collapsing them to the creation time.
+- **Consent "I Agree" no longer looks like a dead button** — a bodyless success response made the API client throw while parsing an empty body, leaving the modal open even though consent was recorded; empty responses now resolve cleanly and a genuine failure shows a visible error.
+- **Catalog and review N+1 queries removed** for faster SRG catalog and component-review loads.
+- Personal access token copy works in non-HTTPS deployments; admin token-revoke justification moved from `window.prompt` to a modal.
+
+## Upgrade notes
+
+- **Run migrations.** Production deploys require `bundle exec rails db:migrate` (the release/entrypoint flow runs it automatically). The SRG-authoring migration is safe for the release phase — its index builds concurrently and its constraints validate without blocking writes.
+- **Self-hosted / Docker: database naming standardization.** The 2.4 line standardizes database names to the Rails convention (`vulcan_development` / `vulcan_test` / `vulcan_production`) and removes the `DB_SUFFIX` environment variable in favor of `DATABASE_NAME`. The container entrypoint's `upgrade:auto` step detects and applies the rename on start; see the [upgrade guide](/deployment/upgrade-guide). Managed Postgres (e.g. Heroku via `DATABASE_URL`) is unaffected.
+- **Backup format is now 1.1** — exports declare `backup_format_version: "1.1"`; older `1.0` archives remain importable.


### PR DESCRIPTION
Add docs/site/release-notes/v2.4.1.md (mirrors the CHANGELOG, with a self-hosted DB-naming upgrade note), point the landing page and release-notes index at v2.4.1, and demote v2.3.7 to Previous Releases. Deploys via docs.yml on merge to master — independent of the release workflow, so it does not touch the published 2.4.1 image or the IronBank MR. (In-app docs baked into the image still lag until the next image build — tracked separately.)