### PR TITLE
Fix/2.4.2 patches

### DIFF
--- a/app/blueprints/component_blueprint.rb
+++ b/app/blueprints/component_blueprint.rb
@@ -127,6 +127,15 @@ class ComponentBlueprint < Blueprinter::Base
     field :releasable do |component, _options|
       component.releasable
     end
+
+    # Lock progress for the card's lock indicator (all-locked vs N-of-M).
+    # Batched via options[:lock_summaries] on the project show page; falls back
+    # to a per-component summary elsewhere. Reads the requirements association,
+    # not a component column, so it is safe under the column-limited
+    # available_components query (which does not select requirement columns).
+    field :lock_summary do |component, options|
+      (options[:lock_summaries] || {})[component.id] || component.lock_summary
+    end
   end
 
   # === Related view: related_rules parents (includes project for display name) ===

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -69,11 +69,13 @@ class ProjectsController < ApplicationController
     # component cards and the project-level total render without N+1.
     component_ids = @project.components.ids
     pending_comment_counts = Component.pending_comment_counts(component_ids)
+    lock_summaries = Component.lock_summaries(component_ids)
     @project_json = ProjectBlueprint.render(
       @project,
       view: :show,
       current_user: current_user,
-      pending_comment_counts: pending_comment_counts
+      pending_comment_counts: pending_comment_counts,
+      lock_summaries: lock_summaries
     )
     respond_to do |format|
       format.html

--- a/app/javascript/components/components/ComponentCard.vue
+++ b/app/javascript/components/components/ComponentCard.vue
@@ -37,6 +37,14 @@
               class="ml-2"
               title="Component Released"
             />
+            <b-icon
+              v-if="lockState"
+              v-b-tooltip.hover
+              :icon="lockState === 'all' ? 'lock-fill' : 'unlock-fill'"
+              variant="secondary"
+              class="ml-2"
+              :title="lockTooltip"
+            />
           </div>
           <!-- Identity / configuration indicator (top-right): rules-count
                only. The pending-triage signal is an action affordance
@@ -217,7 +225,7 @@ import { useConfirmRelease, RELEASE_CONFIRM_COPY } from "../../composables/useCo
 import LockControlsModal from "../components/LockControlsModal.vue";
 import NewComponentModal from "../components/NewComponentModal.vue";
 import UserBadge from "../shared/UserBadge.vue";
-import { messageLabels, ruleCountLabel } from "../../constants/terminology";
+import { messageLabels, ruleCountLabel, ruleTerm } from "../../constants/terminology";
 
 export default {
   name: "ComponentCard",
@@ -265,6 +273,22 @@ export default {
   computed: {
     msg: function () {
       return messageLabels(this.component.document_type);
+    },
+    // Lock indicator state for the card: null (no badge) when nothing is
+    // locked, "all" when every requirement is locked, "partial" otherwise.
+    lockState: function () {
+      const summary = this.component.lock_summary;
+      if (!summary || !summary.total || !summary.locked) return null;
+      return summary.all_locked ? "all" : "partial";
+    },
+    // Kind-aware tooltip: "All rules/requirements locked" or "N of M ... locked".
+    lockTooltip: function () {
+      const summary = this.component.lock_summary;
+      if (!summary) return "";
+      const noun = ruleTerm(this.component.document_type).plural.toLowerCase();
+      return summary.all_locked
+        ? `All ${noun} locked`
+        : `${summary.locked} of ${summary.total} ${noun} locked`;
     },
     releaseComponentTooltip: function () {
       if (this.component.released) {

--- a/app/javascript/constants/exportConfig.js
+++ b/app/javascript/constants/exportConfig.js
@@ -61,6 +61,9 @@ export const ALL_FORMATS = ["csv", "excel", "xccdf", "inspec", "json_archive"];
 // EXCLUDES srg components — mirrors the export service's kind routing,
 // keep in sync.
 export const SRG_VALID_MODE_FORMATS = {
+  // SRGs and STIGs are both XCCDF documents authored the same way, so the
+  // working copy (dump -> bulk-edit -> re-upload) is available for both.
+  working_copy: ["csv", "excel"],
   published_stig: ["xccdf"],
   backup: ["json_archive"],
 };

--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -186,6 +186,33 @@ class Component < ApplicationRecord
     document_type == 'srg' ? authored_srg_rules.count : rules_count
   end
 
+  # Lock progress for the project-page card indicator: how many of this
+  # component's requirements are locked, and whether they all are. Kind-agnostic
+  # via the requirements accessor. On list pages prefer the batched
+  # Component.lock_summaries; this per-component form is the fallback.
+  def lock_summary
+    total = requirements.count
+    locked = requirements.where(locked: true).count
+    { locked: locked, total: total, all_locked: total.positive? && locked == total }
+  end
+
+  # Batched lock summaries keyed by component_id so a project page renders every
+  # card's lock indicator without N+1 — one grouped scan of base_rules (the
+  # type-agnostic requirement table the severity-count scope also counts).
+  # Components with no requirements are absent; callers fall back to an empty
+  # summary.
+  def self.lock_summaries(component_ids)
+    ids = Array(component_ids).compact
+    return {} if ids.empty?
+
+    BaseRule.where(component_id: ids)
+            .group(:component_id)
+            .pluck(:component_id, Arel.sql('COUNT(*)'), Arel.sql('COUNT(*) FILTER (WHERE locked)'))
+            .each_with_object({}) do |(cid, total, locked), acc|
+      acc[cid] = { locked: locked, total: total, all_locked: total.positive? && locked == total }
+    end
+  end
+
   # Requirements that relocated OUT of this component — a lifecycle fact
   # from executed relocation records, never a status bucket. The source
   # rows are tombstoned, so the join reads base_rules unscoped.

--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -793,22 +793,12 @@ class Component < ApplicationRecord
     ).call
   end
 
-  # An SRG component's requirements are authored SrgRules; the spreadsheet
-  # pipeline addresses the Rule family, so against an srg component an update
-  # would silently no-op at best and write to the wrong rows at worst. Both
-  # entry points below refuse through this one message — the single door for
-  # every caller.
-  SPREADSHEET_UPDATE_UNSUPPORTED_FOR_SRG =
-    'Spreadsheet update is not available for SRG components — their ' \
-    'requirements are authored in the editor, not imported from a spreadsheet.'
-
   # Preview changes from a spreadsheet without saving.
   # Returns a hash with :updated, :unchanged, :skipped_locked, :warnings keys,
-  # or { error: "message" } on validation failure.
+  # or { error: "message" } on validation failure. Works for both kinds — the
+  # requirement rows are loaded through the kind seam below.
   def update_from_spreadsheet(spreadsheet, _user = nil)
-    return { error: SPREADSHEET_UPDATE_UNSUPPORTED_FOR_SRG } if document_type == 'srg'
-
-    result = SpreadsheetParser.new(spreadsheet, security_requirements_guide_id).parse_and_validate
+    result = spreadsheet_parser(spreadsheet).parse_and_validate
     return { error: result[:error] } if result.key?(:error)
 
     build_update_comparison(result[:rows])
@@ -817,13 +807,10 @@ class Component < ApplicationRecord
   # Apply changes from a spreadsheet to the database.
   # Returns { success: true, count: N } or { error: "message" }.
   def apply_spreadsheet_update(spreadsheet, _user = nil)
-    return { error: SPREADSHEET_UPDATE_UNSUPPORTED_FOR_SRG } if document_type == 'srg'
-
-    result = SpreadsheetParser.new(spreadsheet, security_requirements_guide_id).parse_and_validate
+    result = spreadsheet_parser(spreadsheet).parse_and_validate
     return { error: result[:error] } if result.key?(:error)
 
-    loaded_rules = rules.eager_load(:disa_rule_descriptions, :checks, :satisfies, :satisfied_by,
-                                    srg_rule: %i[disa_rule_descriptions rule_descriptions checks])
+    loaded_rules = spreadsheet_pipeline_requirements
     rule_by_rule_id = loaded_rules.index_by(&:rule_id)
     rule_by_srg_id = loaded_rules.index_by(&:srg_identifier)
     updated_count = 0
@@ -844,8 +831,30 @@ class Component < ApplicationRecord
       end
     end
 
-    create_rule_satisfactions if updated_count.positive?
+    # The satisfaction graph is STIG-only; authored SRG requirements have none.
+    create_rule_satisfactions if updated_count.positive? && document_type != 'srg'
     { success: true, count: updated_count }
+  end
+
+  # The requirement rows the spreadsheet-update pipeline reads, per kind. STIG
+  # components load Rules with the satisfaction/source-SRG associations the
+  # comparison uses; SRG components load their authored SrgRules with only the
+  # BaseRule-shared associations (no satisfies/satisfied_by/srg_rule).
+  def spreadsheet_pipeline_requirements
+    if document_type == 'srg'
+      requirements.eager_load(:disa_rule_descriptions, :rule_descriptions, :checks, :references)
+    else
+      rules.eager_load(:disa_rule_descriptions, :checks, :satisfies, :satisfied_by,
+                       srg_rule: %i[disa_rule_descriptions rule_descriptions checks])
+    end
+  end
+
+  # Kind-aware spreadsheet parser. STIG components validate the upload's SRG ids
+  # against their source SRG's rules; an SRG component's authored requirements
+  # carry their own versions (not in the source SRG), so validate against those.
+  def spreadsheet_parser(spreadsheet)
+    valid_versions = requirements.map(&:version) if document_type == 'srg'
+    SpreadsheetParser.new(spreadsheet, security_requirements_guide_id, valid_versions: valid_versions)
   end
 
   private
@@ -900,8 +909,7 @@ class Component < ApplicationRecord
   # Build a comparison of spreadsheet rows vs current rule data.
   # Match by STIG ID (unique per rule) to handle multiple rules sharing the same SRG ID.
   def build_update_comparison(rows)
-    loaded_rules = rules.eager_load(:disa_rule_descriptions, :checks, :satisfies, :satisfied_by,
-                                    srg_rule: %i[disa_rule_descriptions rule_descriptions checks])
+    loaded_rules = spreadsheet_pipeline_requirements
     # Build lookup by rule_id (numeric portion of STIG ID)
     rule_by_rule_id = loaded_rules.index_by(&:rule_id)
     # Also build SRG ID lookup for rows without STIG ID

--- a/app/models/srg_rule.rb
+++ b/app/models/srg_rule.rb
@@ -68,6 +68,21 @@ class SrgRule < BaseRule
     !locked
   end
 
+  # Row-editability contract shared with Rule (the spreadsheet-update pipeline
+  # gates each row on it). An authored SRG requirement has no satisfaction graph,
+  # so the row is editable exactly when it is not locked.
+  def row_editable?
+    !locked
+  end
+
+  # CSV positional attributes for the spreadsheet round-trip, in the same order
+  # as Rule#csv_attributes. Built through the kind-aware ExportableRule (the
+  # source-reference / satisfies / InSpec columns are blank for an authored
+  # SrgRule) so the export and the re-import agree on the column layout.
+  def csv_attributes
+    Export::ExportableRule.new(self).values_for(Export::ExportableRule::CSV_KEYS)
+  end
+
   private
 
   # An authored row belongs to a component. During a nested build (the

--- a/app/models/srg_rule.rb
+++ b/app/models/srg_rule.rb
@@ -56,6 +56,18 @@ class SrgRule < BaseRule
     version
   end
 
+  # Field-editability contract shared with Rule (the export/cell-styling layer
+  # calls this on every requirement). An authored SRG requirement locks as a
+  # whole — there are no per-section locks — so a field is editable exactly when
+  # the requirement is not locked. The field key is still validated so an
+  # unknown column is a loud error, matching Rule#field_editable?.
+  def field_editable?(field_key)
+    section = RuleConstants::FIELD_TO_SECTION[field_key.to_sym]
+    raise ArgumentError, "Unknown field for editability check: #{field_key}" unless section
+
+    !locked
+  end
+
   private
 
   # An authored row belongs to a component. During a nested build (the

--- a/app/services/export/exportable_rule.rb
+++ b/app/services/export/exportable_rule.rb
@@ -54,6 +54,14 @@ module Export
 
     private
 
+    # An authored SRG requirement is an SrgRule, not a STIG Rule: it has no
+    # source-SRG reference (srg_rule), no satisfaction graph (satisfied_by), and
+    # no InSpec body. Those columns are blanked; the requirement's own content
+    # fills the authored columns.
+    def srg_kind?
+      rule.is_a?(SrgRule)
+    end
+
     def fetch_nist_control_family
       rule.nist_control_family
     end
@@ -71,6 +79,8 @@ module Export
     end
 
     def fetch_srg_title
+      return nil if srg_kind?
+
       rule.srg_rule.title
     end
 
@@ -79,6 +89,8 @@ module Export
     end
 
     def fetch_srg_vuln_discussion
+      return nil if srg_kind?
+
       rule.srg_rule.disa_rule_descriptions.first&.vuln_discussion
     end
 
@@ -91,10 +103,13 @@ module Export
     end
 
     def fetch_srg_check
+      return nil if srg_kind?
+
       rule.srg_rule.checks.first&.content
     end
 
     def fetch_check_content
+      return rule.checks.first&.content if srg_kind?
       return nil if rule.status == RuleConstants::STATUS_APPLICABLE_DNM && rule.satisfied_by.any?
 
       if rule.satisfied_by.size.positive?
@@ -105,10 +120,13 @@ module Export
     end
 
     def fetch_srg_fix
+      return nil if srg_kind?
+
       rule.srg_rule.fixtext
     end
 
     def fetch_fixtext
+      return rule.fixtext if srg_kind?
       return nil if rule.status == RuleConstants::STATUS_APPLICABLE_DNM && rule.satisfied_by.any?
 
       if rule.satisfied_by.size.positive?
@@ -139,14 +157,20 @@ module Export
     end
 
     def fetch_satisfies
+      return nil if srg_kind?
+
       rule.satisfaction_text(format: :stig, direction: :satisfies)
     end
 
     def fetch_inspec_control_body
+      return nil if srg_kind?
+
       rule.inspec_control_body
     end
 
     def fetch_source
+      return 'Direct' if srg_kind?
+
       rule.satisfied_by.any? ? 'Inherited' : 'Direct'
     end
   end

--- a/app/services/export/modes/working_copy.rb
+++ b/app/services/export/modes/working_copy.rb
@@ -11,6 +11,15 @@ module Export
         Export::ExportableRule::ALL_KEYS
       end
 
+      # SRGs and STIGs are both XCCDF documents authored the same way, so the
+      # working copy is available for both. SRG components load their authored
+      # requirements through srg_eager_load_associations (BaseMode default) and
+      # ExportableRule blanks the source-reference / satisfies / InSpec columns,
+      # which have no meaning for an authored SrgRule.
+      def supports_srg_kind?
+        true
+      end
+
       def headers
         ExportConstants::EXPORT_HEADERS
       end

--- a/app/services/spreadsheet_parser.rb
+++ b/app/services/spreadsheet_parser.rb
@@ -48,9 +48,15 @@ class SpreadsheetParser
 
   # @param spreadsheet [String, ActionDispatch::Http::UploadedFile] path or uploaded file
   # @param srg_id [Integer] SecurityRequirementsGuide ID to validate against
-  def initialize(spreadsheet, srg_id)
+  # @param valid_versions [Array<String>, nil] override the set of acceptable
+  #   SRG-id (version) values. STIG components validate against their source
+  #   SRG's rules (the default); an SRG component's authored requirements carry
+  #   their OWN versions, which are not in the source SRG, so the caller passes
+  #   the component's own requirement versions here.
+  def initialize(spreadsheet, srg_id, valid_versions: nil)
     @spreadsheet = spreadsheet
     @srg_id = srg_id
+    @valid_versions = valid_versions
     @errors = []
   end
 
@@ -69,7 +75,7 @@ class SpreadsheetParser
     return error_result("Missing required headers: #{missing_headers.join(', ')}") unless missing_headers.empty?
 
     srg_rules = SecurityRequirementsGuide.find(@srg_id).srg_rules
-    database_srg_ids = srg_rules.map(&:version)
+    database_srg_ids = @valid_versions || srg_rules.map(&:version)
     spreadsheet_srg_ids = parsed.pluck(IMPORT_MAPPING[:srg_id]).compact_blank
     missing_from_srg = spreadsheet_srg_ids - database_srg_ids
 

--- a/config/vulcan.default.yml
+++ b/config/vulcan.default.yml
@@ -31,16 +31,21 @@ defaults: &defaults
   local_login:
     enabled: <%= ActiveModel::Type::Boolean.new.cast(ENV['VULCAN_ENABLE_LOCAL_LOGIN']) != false %>
     email_confirmation: <%= ActiveModel::Type::Boolean.new.cast(ENV['VULCAN_ENABLE_EMAIL_CONFIRMATION']) || false %>
-    # Accepts: plain seconds (900), or with suffix: 30s, 15m, 1h
+    # A duration for TimeoutParser: plain seconds (900) or a suffix (30s, 15m,
+    # 1h). Emitted with to_json (NOT to_i) so the raw suffix value reaches
+    # TimeoutParser — casting to Integer here strips the suffix ("5m" -> 5 ->
+    # parsed as 5 HOURS) and silently defeats the parser.
     # Default: 3600 (1 hour). The prior 600 (10 min) default timed users out
     # while they were actively working; a proper DoD AC-12 inactivity-based
     # 15-minute timeout (reset the clock on user activity) is a tracked
     # follow-up, at which point this can safely be tightened.
-    session_timeout: <%= (ENV['VULCAN_SESSION_TIMEOUT'] || 3600).to_i %>
+    session_timeout: <%= (ENV['VULCAN_SESSION_TIMEOUT'] || 3600).to_json %>
     remember_me_enabled: <%= ActiveModel::Type::Boolean.new.cast(ENV['VULCAN_ENABLE_REMEMBER_ME']) != false %>
-    # Accepts: plain seconds (28800), or with suffix: 8h, 480m
-    # Default: 28800 (8 hours). Set to 0 to disable remember me entirely.
-    remember_me_duration: <%= (ENV['VULCAN_REMEMBER_ME_DURATION'] || 28800).to_i %>
+    # A duration for TimeoutParser: plain seconds (28800) or a suffix (8h, 480m).
+    # Emitted with to_json (NOT to_i) so the raw suffix value reaches
+    # TimeoutParser (see session_timeout above). Set to 0 to disable.
+    # Default: 28800 (8 hours).
+    remember_me_duration: <%= (ENV['VULCAN_REMEMBER_ME_DURATION'] || 28800).to_json %>
   user_registration:
     enabled: <%= ActiveModel::Type::Boolean.new.cast(ENV['VULCAN_ENABLE_USER_REGISTRATION']) != false %>
   admin_bootstrap:

--- a/config/vulcan.default.yml
+++ b/config/vulcan.default.yml
@@ -31,9 +31,12 @@ defaults: &defaults
   local_login:
     enabled: <%= ActiveModel::Type::Boolean.new.cast(ENV['VULCAN_ENABLE_LOCAL_LOGIN']) != false %>
     email_confirmation: <%= ActiveModel::Type::Boolean.new.cast(ENV['VULCAN_ENABLE_EMAIL_CONFIRMATION']) || false %>
-    # Accepts: plain seconds (600), or with suffix: 10m, 15m, 1h
-    # Default: 600 (10 min) per DoD AC-12 STIG requirement.
-    session_timeout: <%= (ENV['VULCAN_SESSION_TIMEOUT'] || 600).to_i %>
+    # Accepts: plain seconds (900), or with suffix: 30s, 15m, 1h
+    # Default: 3600 (1 hour). The prior 600 (10 min) default timed users out
+    # while they were actively working; a proper DoD AC-12 inactivity-based
+    # 15-minute timeout (reset the clock on user activity) is a tracked
+    # follow-up, at which point this can safely be tightened.
+    session_timeout: <%= (ENV['VULCAN_SESSION_TIMEOUT'] || 3600).to_i %>
     remember_me_enabled: <%= ActiveModel::Type::Boolean.new.cast(ENV['VULCAN_ENABLE_REMEMBER_ME']) != false %>
     # Accepts: plain seconds (28800), or with suffix: 8h, 480m
     # Default: 28800 (8 hours). Set to 0 to disable remember me entirely.

--- a/db/migrate/20260717232022_add_not_null_to_component_based_on.rb
+++ b/db/migrate/20260717232022_add_not_null_to_component_based_on.rb
@@ -6,6 +6,13 @@
 # the validated constraint instead of a full table scan — and drop the now
 # redundant check. Validation raises if any component still has a NULL
 # based_on, so this fails closed rather than fabricating or dropping a parent.
+#
+# Every step is re-runnable. disable_ddl_transaction! means a failure part-way
+# leaves the earlier steps committed while the migration stays unrecorded in
+# schema_migrations, so a retry replays them: without the existence guards, the
+# rerun after a validation failure dies on PG::DuplicateObject instead of
+# resuming. validate_check_constraint and change_column_null are already no-ops
+# when their work is done. Matches AddSrgAuthoringColumns (20260713220000).
 class AddNotNullToComponentBasedOn < ActiveRecord::Migration[8.0]
   disable_ddl_transaction!
 
@@ -13,10 +20,10 @@ class AddNotNullToComponentBasedOn < ActiveRecord::Migration[8.0]
 
   def up
     add_check_constraint :components, 'security_requirements_guide_id IS NOT NULL',
-                         name: CONSTRAINT, validate: false
+                         name: CONSTRAINT, validate: false, if_not_exists: true
     validate_check_constraint :components, name: CONSTRAINT
     change_column_null :components, :security_requirements_guide_id, false
-    remove_check_constraint :components, name: CONSTRAINT
+    remove_check_constraint :components, name: CONSTRAINT, if_exists: true
   end
 
   def down

--- a/doc/openapi.yaml
+++ b/doc/openapi.yaml
@@ -9352,6 +9352,26 @@ components:
                 - 'null'
               description: ID of the source component if this is an overlay. Null for original components.
               example: null
+            lock_summary:
+              type: object
+              description: Lock progress for this component's requirements, powering the project-page lock indicator (an all-locked badge versus an "N of M locked" partial indicator).
+              required:
+                - locked
+                - total
+                - all_locked
+              properties:
+                locked:
+                  type: integer
+                  description: Number of requirements that are locked.
+                  example: 12
+                total:
+                  type: integer
+                  description: Total number of requirements in the component.
+                  example: 30
+                all_locked:
+                  type: boolean
+                  description: True when the component has requirements and every one is locked.
+                  example: false
     ProjectShowResponse:
       description: Full project detail for the project show page. Serialized by ProjectBlueprint :show view. 18 total fields including nested components, memberships, users, access_requests.
       allOf:

--- a/doc/openapi/components/schemas/ComponentIndexResponse.yaml
+++ b/doc/openapi/components/schemas/ComponentIndexResponse.yaml
@@ -26,3 +26,25 @@ allOf:
           - 'null'
         description: ID of the source component if this is an overlay. Null for original components.
         example: null
+      lock_summary:
+        type: object
+        description: >-
+          Lock progress for this component's requirements, powering the project-page
+          lock indicator (an all-locked badge versus an "N of M locked" partial indicator).
+        required:
+          - locked
+          - total
+          - all_locked
+        properties:
+          locked:
+            type: integer
+            description: Number of requirements that are locked.
+            example: 12
+          total:
+            type: integer
+            description: Total number of requirements in the component.
+            example: 30
+          all_locked:
+            type: boolean
+            description: True when the component has requirements and every one is locked.
+            example: false

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -63,13 +63,19 @@ services:
     depends_on:
       db:
         condition: service_healthy
+    # Setup steps run sequentially in the foreground; `bash -e` aborts the
+    # container if any of them fail, so a failed db:prepare surfaces as a dead
+    # container instead of a booted server that raises PendingMigrationError on
+    # every request. Only the asset watcher is backgrounded — `;` separators
+    # scope the trailing `&` to `yarn build:watch` alone. `exec` hands PID 1 to
+    # Puma so docker stop/Ctrl-C signals reach it directly.
     command: >
-      bash -c "rm -f tmp/pids/server.pid &&
-      bin/rails db:prepare &&
-      yarn install --frozen-lockfile &&
-      yarn build &&
+      bash -ec "rm -f tmp/pids/server.pid;
+      bin/rails db:prepare;
+      yarn install --frozen-lockfile;
+      yarn build;
       yarn build:watch &
-      bundle exec rails server -b 0.0.0.0 -p 3000"
+      exec bundle exec rails server -b 0.0.0.0 -p 3000"
 
 volumes:
   vulcan_dev_dbdata:

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -216,9 +216,10 @@ export default defineConfig({
         ],
       },
       {
-        text: "v2.3.7",
+        text: "v2.4.1",
         items: [
-          { text: "Release Notes", link: "/release-notes/v2.3.7" },
+          { text: "Release Notes", link: "/release-notes/v2.4.1" },
+          { text: "v2.3.7", link: "/release-notes/v2.3.7" },
           { text: "v2.3.6", link: "/release-notes/v2.3.6" },
           { text: "v2.3.5", link: "/release-notes/v2.3.5" },
           { text: "v2.3.4", link: "/release-notes/v2.3.4" },

--- a/spec/config/docs_version_consistency_spec.rb
+++ b/spec/config/docs_version_consistency_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+##
+# Hard block against the docs site silently lagging a release.
+#
+# release_infrastructure_spec already enforces VERSION == package.json ==
+# Vulcan::VERSION, but the docs-site "latest release" surfaces were never
+# covered: v2.4.1 shipped while the docs still advertised v2.3.7, because the
+# version bump swept the code but not docs/site — and even the first docs fix
+# missed the VitePress nav dropdown in config.mjs. This spec asserts EVERY
+# "current release" surface in the docs matches the code version, so a bump
+# that misses any one of them fails the suite (and therefore CI).
+#
+# The version is read from Vulcan::VERSION (the single source of truth), never
+# hardcoded, so this guard needs no edit at each release.
+RSpec.describe 'docs/site version consistency' do
+  def site_root
+    Rails.root.join('docs/site')
+  end
+
+  # The version advertised in the landing page's "Current Version" info block.
+  def landing_current_version
+    block = site_root.join('index.md').read[/:::\s*info\s+Current Version.*?:::/m]
+    block && block[/\*\*v(\d+\.\d+\.\d+)\*\*/, 1]
+  end
+
+  # The version listed under the release-notes index "Current Release" heading
+  # (bounded to that section so "Previous Releases" entries are ignored).
+  def release_notes_current_version
+    section = site_root.join('release-notes/index.md').read[/^##\s*Current Release\b.*?(?=^##\s|\z)/m]
+    section && section[/\*\*\[v(\d+\.\d+\.\d+)\]/, 1]
+  end
+
+  # The version presented as current in the VitePress nav's release-notes
+  # dropdown: [label, current "Release Notes" link target]. Nil if the dropdown
+  # can't be located (its structure changed — the guard should then be updated).
+  def nav_current_versions
+    config = Rails.root.join('docs/.vitepress/config.mjs').read
+    match = config.match(
+      %r{text:\s*["']v(\d+\.\d+\.\d+)["'],\s*items:\s*\[\s*\{\s*text:\s*["']Release Notes["'],\s*link:\s*["']/release-notes/v(\d+\.\d+\.\d+)["']}m
+    )
+    match && [match[1], match[2]]
+  end
+
+  it 'landing page advertises the current code version as the latest release' do
+    expect(landing_current_version).to eq(Vulcan::VERSION),
+                                       "docs/site/index.md 'Current Version' is " \
+                                       "#{landing_current_version.inspect}, but Vulcan::VERSION is " \
+                                       "#{Vulcan::VERSION.inspect} — update the docs to match the release."
+  end
+
+  it 'release-notes index lists the current code version as the current release' do
+    expect(release_notes_current_version).to eq(Vulcan::VERSION),
+                                             "docs/site/release-notes/index.md 'Current Release' is " \
+                                             "#{release_notes_current_version.inspect}, but Vulcan::VERSION is " \
+                                             "#{Vulcan::VERSION.inspect} — update the docs to match the release."
+  end
+
+  it 'release-notes nav dropdown in config.mjs points at the current version' do
+    versions = nav_current_versions
+    expect(versions).not_to(be_nil,
+                            'could not locate the release-notes version dropdown in ' \
+                            'docs/.vitepress/config.mjs — the nav structure changed; update this guard.')
+    expect(versions).to all(eq(Vulcan::VERSION)),
+                        "the config.mjs release-notes nav (label + current 'Release Notes' link) is " \
+                        "#{versions.inspect}, but Vulcan::VERSION is #{Vulcan::VERSION.inspect} — " \
+                        'update the nav dropdown label and its Release Notes link to match the release.'
+  end
+
+  it 'ships a release-notes page for the current version' do
+    page = site_root.join("release-notes/v#{Vulcan::VERSION}.md")
+    expect(page).to exist,
+                    "missing #{page.relative_path_from(Rails.root)} — a version bump must ship its " \
+                    'release-notes page, not just move the latest-release pointer.'
+  end
+end

--- a/spec/config/settings_defaults_spec.rb
+++ b/spec/config/settings_defaults_spec.rb
@@ -208,8 +208,6 @@ RSpec.describe 'Settings defaults' do
       'password.min_lowercase' => -> { Settings.password.min_lowercase },
       'password.min_number' => -> { Settings.password.min_number },
       'password.min_special' => -> { Settings.password.min_special },
-      'local_login.session_timeout' => -> { Settings.local_login.session_timeout },
-      'local_login.remember_me_duration' => -> { Settings.local_login.remember_me_duration },
       'lockout.maximum_attempts' => -> { Settings.lockout.maximum_attempts },
       'lockout.unlock_in_minutes' => -> { Settings.lockout.unlock_in_minutes },
       'session_limits.max_sessions' => -> { Settings.session_limits.max_sessions },
@@ -223,6 +221,23 @@ RSpec.describe 'Settings defaults' do
         value = accessor.call
         expect(value).to be_a(Integer),
                          "Expected Settings.#{path} to be Integer, got #{value.class} (#{value.inspect})"
+      end
+    end
+  end
+
+  # session_timeout and remember_me_duration are duration INPUTS, not raw
+  # integers: the template emits the raw value (plain seconds or a suffix like
+  # "5m"/"1h") and TimeoutParser interprets it at consumption. Casting them to
+  # Integer in the template would strip the suffix ("5m" -> 5 -> 5 hours) and
+  # silently defeat the parser, so they are validated on their EFFECTIVE value.
+  describe 'timeout duration settings resolve to a positive number of seconds' do
+    {
+      'local_login.session_timeout' => -> { Settings.local_login.session_timeout },
+      'local_login.remember_me_duration' => -> { Settings.local_login.remember_me_duration }
+    }.each do |path, accessor|
+      it "TimeoutParser.parse(Settings.#{path}) is a positive Integer" do
+        parsed = TimeoutParser.parse(accessor.call)
+        expect(parsed).to be_a(Integer).and be_positive
       end
     end
   end

--- a/spec/javascript/components/components/ComponentCard.spec.js
+++ b/spec/javascript/components/components/ComponentCard.spec.js
@@ -211,6 +211,42 @@ describe("ComponentCard", () => {
       expect(html).toContain("patch-check-fill");
     });
 
+    // REQUIREMENT: locking a component's requirements must be visible on the
+    // project page. A solid lock (lock-fill) means every requirement is locked;
+    // an open lock (unlock-fill) with an "N of M locked" tooltip means partial;
+    // nothing locked shows no badge (absence is the meaningful state).
+    describe("lock indicator", () => {
+      const withLock = (lock_summary) => ({
+        component: { ...defaultComponent, lock_summary },
+      });
+
+      it("shows a solid lock (lock-fill) when every requirement is locked", () => {
+        wrapper = createWrapper(withLock({ locked: 10, total: 10, all_locked: true }));
+        expect(wrapper.find(".bi-lock-fill").exists()).toBe(true);
+        expect(wrapper.find(".bi-unlock-fill").exists()).toBe(false);
+        expect(wrapper.html()).toMatch(/All \w+ locked/);
+      });
+
+      it("shows an open lock (unlock-fill) with N-of-M when only some are locked", () => {
+        wrapper = createWrapper(withLock({ locked: 3, total: 10, all_locked: false }));
+        expect(wrapper.find(".bi-unlock-fill").exists()).toBe(true);
+        expect(wrapper.find(".bi-lock-fill").exists()).toBe(false);
+        expect(wrapper.html()).toMatch(/3 of 10 \w+ locked/);
+      });
+
+      it("shows no lock indicator when nothing is locked", () => {
+        wrapper = createWrapper(withLock({ locked: 0, total: 10, all_locked: false }));
+        expect(wrapper.find(".bi-lock-fill").exists()).toBe(false);
+        expect(wrapper.find(".bi-unlock-fill").exists()).toBe(false);
+      });
+
+      it("shows no lock indicator when lock_summary is absent", () => {
+        wrapper = createWrapper();
+        expect(wrapper.find(".bi-lock-fill").exists()).toBe(false);
+        expect(wrapper.find(".bi-unlock-fill").exists()).toBe(false);
+      });
+    });
+
     // REQUIREMENT: pending-comment pill links to the full-page triage view
     // (the slideover was retired). Anchor must point at /components/:id/triage,
     // NOT the legacy /components/:id#comments hash URL.

--- a/spec/javascript/components/shared/ExportModal.spec.js
+++ b/spec/javascript/components/shared/ExportModal.spec.js
@@ -212,8 +212,8 @@ describe("ExportModal", () => {
 
     it("select-all skips excluded SRG components and the tri-state counts only selectable ones", async () => {
       wrapper = createWrapper({ components: withSrg });
-      // working_copy has no SRG meaning → SRG components are excluded.
-      wrapper.vm.selectedMode = "working_copy";
+      // vendor_submission has no SRG meaning → SRG components are excluded.
+      wrapper.vm.selectedMode = "vendor_submission";
       await wrapper.vm.$nextTick();
 
       expect(wrapper.vm.isSrgExcludedSelection).toBe(true);
@@ -1437,7 +1437,9 @@ describe("ExportModal", () => {
     it("disables purposes with no srg meaning when every component is srg", () => {
       wrapper = createWrapper({ components: [srgComponent], availableModes: allModes });
 
-      expect(modeInput("working_copy").attributes("disabled")).toBeDefined();
+      // working_copy now serves SRG components (same-as-STIG export), so it is
+      // enabled; vendor_submission still has no SRG meaning and stays disabled.
+      expect(modeInput("working_copy").attributes("disabled")).toBeUndefined();
       expect(modeInput("vendor_submission").attributes("disabled")).toBeDefined();
       expect(modeInput("published_stig").attributes("disabled")).toBeUndefined();
       expect(modeInput("backup").attributes("disabled")).toBeUndefined();
@@ -1451,7 +1453,7 @@ describe("ExportModal", () => {
       });
 
       wrapper.vm.selectedComponentIds = [1, 9];
-      wrapper.vm.selectedMode = "working_copy";
+      wrapper.vm.selectedMode = "vendor_submission";
       await wrapper.vm.$nextTick();
 
       expect(wrapper.vm.selectedComponentIds).toEqual([1]);
@@ -1467,6 +1469,20 @@ describe("ExportModal", () => {
 
       wrapper.vm.selectedComponentIds = [1, 9];
       wrapper.vm.selectedMode = "published_stig";
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.vm.selectedComponentIds).toEqual([1, 9]);
+      expect(wrapper.find('[data-testid="srg-exclusion-warning"]').exists()).toBe(false);
+    });
+
+    it("keeps srg components selectable under the working-copy purpose (same-as-STIG export)", async () => {
+      wrapper = createWrapper({
+        components: [stigComponent, srgComponent],
+        availableModes: allModes,
+      });
+
+      wrapper.vm.selectedComponentIds = [1, 9];
+      wrapper.vm.selectedMode = "working_copy";
       await wrapper.vm.$nextTick();
 
       expect(wrapper.vm.selectedComponentIds).toEqual([1, 9]);

--- a/spec/models/component_roundtrip_spec.rb
+++ b/spec/models/component_roundtrip_spec.rb
@@ -496,4 +496,42 @@ RSpec.describe Component, '#update_from_spreadsheet / #apply_spreadsheet_update'
       expect(rule.title).to eq(original_title)
     end
   end
+
+  # ========================================================================
+  # 15. SRG components get the same round-trip (dump -> edit -> re-upload)
+  # ========================================================================
+  describe 'SRG component round-trip' do
+    let_it_be(:srg_component) do
+      create(:component, :skip_rules, document_type: 'srg', prefix: 'SRGT-00')
+    end
+    let_it_be(:srg_requirement) do
+      create(:srg_rule, :authored,
+             component: srg_component,
+             title: 'Original SRG requirement title',
+             status: 'Applicable', rule_severity: 'medium')
+    end
+
+    it 'persists an edited title back to the authored SrgRule' do
+      parsed = export_and_parse_csv(srg_component)
+      parsed[0]['Requirement'] = 'EDITED SRG REQUIREMENT TITLE'
+
+      path = csv_to_tempfile(parsed)
+      result = srg_component.apply_spreadsheet_update(path, user)
+
+      expect(result[:error]).to be_nil
+      expect(result[:success]).to be true
+      expect(result[:count]).to be >= 1
+
+      expect(srg_requirement.reload.title).to eq('EDITED SRG REQUIREMENT TITLE')
+    end
+
+    it 'is idempotent: re-uploading an unedited export makes 0 changes' do
+      parsed = export_and_parse_csv(srg_component)
+      path = csv_to_tempfile(parsed)
+      result = srg_component.update_from_spreadsheet(path, user)
+
+      expect(result[:error]).to be_nil
+      expect(result[:updated]).to be_empty
+    end
+  end
 end

--- a/spec/requests/components_update_spreadsheet_spec.rb
+++ b/spec/requests/components_update_spreadsheet_spec.rb
@@ -211,10 +211,10 @@ RSpec.describe 'Components spreadsheet update endpoints' do
     end
   end
 
-  # An SRG component's requirements are authored SrgRules — the spreadsheet
-  # pipeline addresses the Rule family, so against an srg component the update
-  # silently no-ops at best and writes to the wrong rows at worst. Both
-  # endpoints must refuse loudly, never quietly succeed with zero changes.
+  # SRG components now round-trip through the spreadsheet like STIG components
+  # (dump -> edit -> re-upload). A spreadsheet whose SRG ids do not match the
+  # component's own authored requirements must still be refused LOUDLY (a clear
+  # 422), never silently succeed with zero changes.
   describe 'against an SRG-kind component' do
     let_it_be(:srg_component) do
       create(:component, :skip_rules, project: project, document_type: 'srg',
@@ -231,7 +231,7 @@ RSpec.describe 'Components spreadsheet update endpoints' do
            params: { file: Rack::Test::UploadedFile.new(file.path, 'text/csv') }
 
       expect(response).to have_http_status(:unprocessable_content)
-      expect(response.parsed_body['error']).to eq(Component::SPREADSHEET_UPDATE_UNSUPPORTED_FOR_SRG)
+      expect(response.parsed_body['error']).to include('not found in selected SRG')
     end
 
     it 'refuses an apply with a clear error instead of a silent no-op' do
@@ -241,7 +241,7 @@ RSpec.describe 'Components spreadsheet update endpoints' do
             params: { file: Rack::Test::UploadedFile.new(file.path, 'text/csv') }
 
       expect(response).to have_http_status(:unprocessable_content)
-      expect(response.parsed_body['error']).to eq(Component::SPREADSHEET_UPDATE_UNSUPPORTED_FOR_SRG)
+      expect(response.parsed_body['error']).to include('not found in selected SRG')
     end
   end
 end

--- a/spec/requests/projects_export_spec.rb
+++ b/spec/requests/projects_export_spec.rb
@@ -44,9 +44,11 @@ RSpec.describe 'Project Exports' do
   # ==========================================================================
   # REQUIREMENT (kind routing): project exports serve BOTH document kinds.
   # xccdf kind-routes each component (srg -> published_srg, exactly like the
-  # per-component route); purposes with no srg meaning (working copy csv,
-  # excel, inspec, vendor submission) EXCLUDE srg components from the output
-  # — never a silently empty archive member. An export whose every component
+  # per-component route). The WORKING COPY serves both kinds directly — SRGs
+  # and STIGs are XCCDF documents authored the same way, so csv/excel carry
+  # srg components rather than skipping them. Purposes with no srg meaning
+  # (inspec, vendor submission) EXCLUDE srg components from the output —
+  # never a silently empty archive member. An export whose every component
   # is excluded refuses loudly instead of producing an empty artifact.
   # ==========================================================================
   describe 'kind routing for SRG components' do
@@ -60,43 +62,35 @@ RSpec.describe 'Project Exports' do
                                    status: 'Applicable', title: 'Exportable authored requirement')
     end
 
-    def zip_entries(body)
-      entries = {}
-      Zip::File.open_buffer(StringIO.new(body)) do |zip|
-        zip.each { |e| entries[e.name] = zip.read(e.name) }
-      end
-      entries
-    end
-
     it 'project xccdf export renders the srg component through the published_srg mode' do
       get "/projects/#{project.id}/export/xccdf", headers: { 'Accept' => 'text/html' }
       expect(response).to have_http_status(:success)
 
-      entries = zip_entries(response.body)
-      srg_entry = entries.keys.find { |n| n.start_with?('PXPT-00') }
-      expect(srg_entry).to be_present, "srg member missing from archive: #{entries.keys}"
+      names = zip_entries(response.body)
+      srg_entry = names.find { |n| n.start_with?('PXPT-00') }
+      expect(srg_entry).to be_present, "srg member missing from archive: #{names}"
 
-      doc = Nokogiri::XML(entries[srg_entry])
-      groups = doc.css('Group')
-      expect(groups.size).to eq(1)
-      expect(entries[srg_entry]).to include('Exportable authored requirement')
+      srg_xml = zip_read(response.body, srg_entry)
+      expect(Nokogiri::XML(srg_xml).css('Group').size).to eq(1)
+      expect(srg_xml).to include('Exportable authored requirement')
 
       # The stig component still exports through its own mode in the same archive.
-      stig_entry = entries.keys.find { |n| n.start_with?(component.prefix) }
-      expect(stig_entry).to be_present
+      expect(names.find { |n| n.start_with?(component.prefix) }).to be_present
     end
 
-    it 'excludes the srg component from the project csv export with no empty member' do
+    it 'serves the srg component in the project csv export' do
       get "/projects/#{project.id}/export/csv", headers: { 'Accept' => 'text/html' }
       expect(response).to have_http_status(:success)
 
-      # With the srg component excluded, one CSV remains and Packager passes
-      # it through directly (no single-member zip) — the established
-      # one-result semantics.
-      expect(response.headers['Content-Type']).to include('text/csv')
-      expect(response.headers['Content-Disposition']).to include(component.prefix)
-      expect(response.headers['Content-Disposition']).not_to include('PXPT')
-      expect(response.body).not_to include('Exportable authored requirement')
+      # The working copy has srg meaning, so BOTH components produce a CSV and
+      # Packager zips the pair — the srg member carries its authored
+      # requirement rather than being dropped from the run.
+      names = zip_entries(response.body)
+      srg_entry = names.find { |n| n.include?('PXPT-00') }
+      expect(srg_entry).to be_present, "srg member missing from archive: #{names}"
+      expect(zip_read(response.body, srg_entry)).to include('Exportable authored requirement')
+
+      expect(names.find { |n| n.include?(component.prefix) }).to be_present
     end
 
     it 'excludes the srg component from the project inspec export' do
@@ -105,16 +99,20 @@ RSpec.describe 'Project Exports' do
 
       # InSpec batch archives name entries by component NAME directory,
       # not prefix — grep the directory the srg component would get.
-      entries = zip_entries(response.body)
-      expect(entries.keys.grep(/Project-Export-SRG/)).to be_empty
-      expect(entries.keys.grep(/#{component.name.tr(' ', '-')}/)).not_to be_empty
+      names = zip_entries(response.body)
+      expect(names.grep(/Project-Export-SRG/)).to be_empty
+      expect(names.grep(/#{component.name.tr(' ', '-')}/)).not_to be_empty
     end
 
     it 'refuses loudly when every selected component is excluded by the purpose' do
-      get "/projects/#{project.id}/export/csv?component_ids=#{srg_component.id}",
+      # vendor_submission is the purpose with no srg meaning now that the
+      # working copy serves both kinds.
+      get "/projects/#{project.id}/export/excel?mode=vendor_submission&component_ids=#{srg_component.id}",
           headers: { 'Accept' => 'text/html' }
 
       expect(response).to have_http_status(:unprocessable_content)
+      # Pin the reason: a 422 from any other guard must not satisfy this.
+      expect(response.body).to include('None of the selected components support this export purpose.')
     end
   end
 end

--- a/spec/requests/projects_show_spec.rb
+++ b/spec/requests/projects_show_spec.rb
@@ -81,6 +81,54 @@ RSpec.describe 'GET /projects/:id' do
     end
   end
 
+  describe 'lock_summary (ComponentBlueprint :index)' do
+    it 'reports all_locked when every requirement is locked' do
+      locked_component = create(:component, :skip_rules, project: project, document_type: 'srg',
+                                                         prefix: 'LSRG-00', name: 'Locked SRG',
+                                                         title: 'Locked SRG')
+      create(:srg_rule, :authored, component: locked_component, rule_id: '000001',
+                                   status: 'Applicable', locked: true)
+      create(:srg_rule, :authored, component: locked_component, rule_id: '000002',
+                                   status: 'Applicable', locked: true)
+
+      get "/projects/#{project.id}", as: :json
+
+      row = response.parsed_body['components'].find { |c| c['id'] == locked_component.id }
+      expect(row['lock_summary']).to include('locked' => 2, 'total' => 2, 'all_locked' => true)
+    end
+
+    it 'reports a partial lock when only some requirements are locked' do
+      partial = create(:component, :skip_rules, project: project, document_type: 'srg',
+                                                prefix: 'PLSR-00', name: 'Partial SRG',
+                                                title: 'Partial SRG')
+      create(:srg_rule, :authored, component: partial, rule_id: '000001',
+                                   status: 'Applicable', locked: true)
+      create(:srg_rule, :authored, component: partial, rule_id: '000002',
+                                   status: 'Applicable', locked: false)
+
+      get "/projects/#{project.id}", as: :json
+
+      row = response.parsed_body['components'].find { |c| c['id'] == partial.id }
+      expect(row['lock_summary']).to include('locked' => 1, 'total' => 2, 'all_locked' => false)
+    end
+
+    it 'serves lock_summary through the column-limited available_components path' do
+      other_project = create(:project)
+      released = create(:component, :skip_rules, project: other_project, document_type: 'srg',
+                                                 prefix: 'ALSR-00', name: 'Available Locked SRG',
+                                                 title: 'Available Locked SRG')
+      create(:srg_rule, :authored, component: released, rule_id: '000001',
+                                   status: 'Applicable', locked: true)
+      released.update!(released: true, via_release_flow: true)
+
+      get "/projects/#{project.id}", as: :json
+
+      expect(response).to have_http_status(:success)
+      row = response.parsed_body['available_components'].find { |c| c['id'] == released.id }
+      expect(row['lock_summary']).to include('locked' => 1, 'total' => 1, 'all_locked' => true)
+    end
+  end
+
   describe 'effective_permissions in JSON response' do
     it 'includes effective_permissions=admin for project admin' do
       get "/projects/#{project.id}", as: :json

--- a/spec/requests/registrations_spec.rb
+++ b/spec/requests/registrations_spec.rb
@@ -424,8 +424,14 @@ RSpec.describe 'User Registrations' do
   end
 
   describe 'session timeout default' do
-    it 'defaults to 600 seconds (10 min) per DoD AC-12 STIG requirement' do
-      expect(Settings.local_login.session_timeout).to eq(600)
+    # The prior 600s (10 min) default timed users out while they were actively
+    # working. A proper DoD AC-12 inactivity-based timeout (reset on activity)
+    # is a tracked follow-up; until then the effective default is 1 hour.
+    # Assert the EFFECTIVE (parsed) timeout, not the raw setting: the raw value
+    # is env-dependent (VULCAN_SESSION_TIMEOUT may be set) and only becomes a
+    # duration once TimeoutParser interprets it — the same path Devise uses.
+    it 'resolves to a 1-hour (3600s) effective timeout by default' do
+      expect(TimeoutParser.parse(Settings.local_login.session_timeout)).to eq(3600)
     end
   end
 

--- a/spec/services/export/base_spec.rb
+++ b/spec/services/export/base_spec.rb
@@ -121,7 +121,8 @@ RSpec.describe Export::Base do
     end
 
     it 'raises NoExportableComponents for an srg-only selection on a purpose with no srg meaning' do
-      export = described_class.new(exportable: refusal_component, mode: :working_copy, format: :csv)
+      # vendor_submission has no srg meaning (working_copy now serves both kinds).
+      export = described_class.new(exportable: refusal_component, mode: :vendor_submission, format: :excel)
       expect { export.call }.to raise_error(
         Export::Base::NoExportableComponents,
         'None of the selected components support this export purpose.'
@@ -130,18 +131,20 @@ RSpec.describe Export::Base do
 
     it 'refuses a counterpart mode that does not opt into srg kind' do
       # No shipped mode misroutes today — construct the misconfiguration: a
-      # published_stig whose counterpart is working_copy (a valid Registry
-      # combination for :inspec, but NOT srg-capable). Without the mode_for
-      # guard this export would produce a silently empty archive.
-      misrouting_mode = Class.new(Export::Modes::PublishedStig) do
+      # vendor_submission (a valid Registry combination for :excel, but NOT
+      # srg-capable) whose counterpart is itself, another non-srg-capable mode.
+      # Without the mode_for guard this export would produce a silently empty
+      # archive. (working_copy can no longer play the non-srg counterpart — it
+      # now serves both kinds.)
+      misrouting_mode = Class.new(Export::Modes::VendorSubmission) do
         def srg_counterpart
-          :working_copy
+          :vendor_submission
         end
       end
       allow(Export::Registry).to receive(:mode_class).and_call_original
-      allow(Export::Registry).to receive(:mode_class).with(:published_stig).and_return(misrouting_mode)
+      allow(Export::Registry).to receive(:mode_class).with(:vendor_submission).and_return(misrouting_mode)
 
-      export = described_class.new(exportable: refusal_component, mode: :published_stig, format: :inspec)
+      export = described_class.new(exportable: refusal_component, mode: :vendor_submission, format: :excel)
       expect { export.call }.to raise_error(Export::Base::NoExportableComponents)
     end
   end

--- a/spec/services/export/working_copy_srg_spec.rb
+++ b/spec/services/export/working_copy_srg_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+##
+# SRG components get the same tabular export as STIG components. The kind seam
+# (Export::Base reads component.requirements when the mode supports_srg_kind?)
+# lets working_copy serve an SRG component's authored requirements; ExportableRule
+# emits the SrgRule's own content in the authored columns and blanks the
+# source-reference / satisfies / InSpec columns, which have no SRG meaning.
+RSpec.describe 'Export::Base working_copy for SRG components' do
+  let(:srg_component) do
+    create(:component, :skip_rules, document_type: 'srg', prefix: 'ABCD-00')
+  end
+
+  let!(:requirement) do
+    create(:srg_rule, :authored,
+           component: srg_component,
+           title: 'Authored SRG requirement one',
+           status: 'Applicable',
+           rule_severity: 'medium')
+  end
+
+  it 'exports an SRG component as a working-copy CSV without raising' do
+    result = described_class_export(:csv)
+    expect(result.data).to include('Authored SRG requirement one')
+  end
+
+  it 'exports an SRG component as a working-copy Excel without raising' do
+    result = described_class_export(:excel)
+    expect(result.data).to be_present
+    expect(result.content_type).to match(/spreadsheet|excel|officedocument/i)
+  end
+
+  def described_class_export(format)
+    Export::Base.new(exportable: srg_component, mode: :working_copy, format: format).call
+  end
+end


### PR DESCRIPTION
- [x] add ability to export a working copy of an SRG
- [x] revert overly aggressive inactivity timeout -- reverted back to an hour for now, but later work will be building an activity timeout that actually resets when the user interacts with the app -- in 2.4.1 the app would log out at 15 minutes _regardless of whether it was being actively used_
- [x] related fix -- VULCAN_SESSION_TIMEOUT wasn't respecting the letter character determining the unit of time. So setting '5m' would still become a 5 hour timeout. Fixed
- [x] Component-lock indicator from project view   